### PR TITLE
Feature/create-group-api

### DIFF
--- a/src/api/endpoints/group.ts
+++ b/src/api/endpoints/group.ts
@@ -1,0 +1,7 @@
+import apiClient from '@/api/client';
+import type { CreateGroupPayload, CreateGroupResponse } from '@/types/group';
+
+const createGroup = (payload: CreateGroupPayload) =>
+  apiClient.post<CreateGroupResponse>('/api/care-groups', payload);
+
+export default createGroup;

--- a/src/features/groups/components/GroupEntryDrawer.tsx
+++ b/src/features/groups/components/GroupEntryDrawer.tsx
@@ -11,6 +11,7 @@ import {
   RoundedButtonPrimary,
   RoundedButtonSecondary,
 } from '@/components/common/RoundedButtons';
+import useCreateGroup from '@/features/groups/hooks/useCreateGroup';
 import cn from '@/lib/utils';
 
 type DrawerStep = 'entry' | 'create' | 'success';
@@ -115,10 +116,11 @@ function GroupEntryDrawer({
   mode = 'create',
   initialGroupName = '',
 }: GroupEntryDrawerProps) {
+  const { isLoading, handleCreateGroup } = useCreateGroup();
   const [step, setStep] = useState<DrawerStep>(initialStep);
   const [careRecipientName, setCareRecipientName] = useState(initialGroupName);
   const [gender, setGender] = useState('male');
-  const [birthDate] = useState('2026/01/12');
+  const [birthDate] = useState('2026-04-01');
   const isEditMode = mode === 'edit';
   const canSubmit = careRecipientName.trim().length > 0;
   const successTitle = isEditMode ? '編輯完成！' : '創建完成！';
@@ -147,6 +149,26 @@ function GroupEntryDrawer({
     }
 
     onClose?.();
+  };
+
+  const handleSubmit = async () => {
+    if (!canSubmit) return;
+
+    if (isEditMode) {
+      setStep('success');
+      return;
+    }
+
+    try {
+      await handleCreateGroup({
+        recipientName: careRecipientName,
+        recipientGender: gender,
+        recipientBirthDate: birthDate,
+      });
+      setStep('success');
+    } catch {
+      // 錯誤已於上一層 hook 處理。
+    }
   };
 
   if (step === 'success') {
@@ -261,10 +283,10 @@ function GroupEntryDrawer({
           </div>
 
           <RoundedButtonPrimary
-            onClick={() => setStep('success')}
-            disabled={!canSubmit}
+            onClick={handleSubmit}
+            disabled={!canSubmit || isLoading}
           >
-            {submitLabel}
+            {isLoading ? '建立中...' : submitLabel}
           </RoundedButtonPrimary>
         </div>
       </div>

--- a/src/features/groups/components/GroupEntryDrawer.tsx
+++ b/src/features/groups/components/GroupEntryDrawer.tsx
@@ -159,15 +159,14 @@ function GroupEntryDrawer({
       return;
     }
 
-    try {
-      await handleCreateGroup({
-        recipientName: careRecipientName,
-        recipientGender: gender,
-        recipientBirthDate: birthDate,
-      });
+    const result = await handleCreateGroup({
+      recipientName: careRecipientName,
+      recipientGender: gender,
+      recipientBirthDate: birthDate,
+    });
+
+    if (result) {
       setStep('success');
-    } catch {
-      // 錯誤已於上一層 hook 處理。
     }
   };
 

--- a/src/features/groups/hooks/useCreateGroup.ts
+++ b/src/features/groups/hooks/useCreateGroup.ts
@@ -1,0 +1,41 @@
+import { useState } from 'react';
+
+import axios from 'axios';
+import { toast } from 'sonner';
+
+import createGroup from '@/api/endpoints/group';
+import type { CreateGroupPayload } from '@/types/group';
+
+const useCreateGroup = () => {
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleCreateGroup = async (payload: CreateGroupPayload) => {
+    setIsLoading(true);
+    try {
+      const res = await createGroup(payload);
+      toast.success(res.data.message);
+      return res.data.data;
+    } catch (error) {
+      if (axios.isAxiosError(error)) {
+        switch (error.response?.status) {
+          case 400:
+            toast.error('請確認群組資料格式是否正確');
+            break;
+          case 401:
+            toast.error('請先登入後再建立群組');
+            break;
+          default:
+            toast.error('建立群組失敗，請稍後再試');
+            break;
+        }
+      }
+      return null;
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return { isLoading, handleCreateGroup };
+};
+
+export default useCreateGroup;

--- a/src/features/groups/hooks/useCreateGroup.ts
+++ b/src/features/groups/hooks/useCreateGroup.ts
@@ -13,6 +13,7 @@ const useCreateGroup = () => {
     setIsLoading(true);
     try {
       const res = await createGroup(payload);
+      window.localStorage.setItem('currentGroupId', res.data.data.id);
       toast.success(res.data.message);
       return res.data.data;
     } catch (error) {

--- a/src/pages/GroupEntrance/GroupEntrancePage.tsx
+++ b/src/pages/GroupEntrance/GroupEntrancePage.tsx
@@ -13,6 +13,14 @@ function GroupEntrancePage() {
   const [isGroupInviteDrawerOpen, setIsGroupInviteDrawerOpen] = useState(false);
   const navigate = useNavigate();
 
+  const handleGroupInviteDrawerChange = (open: boolean) => {
+    setIsGroupInviteDrawerOpen(open);
+
+    if (!open) {
+      navigate('/homepage');
+    }
+  };
+
   return (
     <>
       <GroupEntranceLayout
@@ -35,7 +43,7 @@ function GroupEntrancePage() {
 
       <GroupInviteDrawer
         open={isGroupInviteDrawerOpen}
-        onOpenChange={setIsGroupInviteDrawerOpen}
+        onOpenChange={handleGroupInviteDrawerChange}
       />
     </>
   );

--- a/src/types/group.ts
+++ b/src/types/group.ts
@@ -17,19 +17,11 @@ type CareGroupInfo = {
   memberCount: number;
 };
 
-type Pagination = {
-  totalCount: number;
-  totalPages: number;
-  currentPage: number;
-  pageSize: number;
-};
-
 type CreateGroupResponse = {
   success: boolean;
   message: string;
   data: CareGroupInfo;
   traceId: string;
-  pagination: Pagination;
 };
 
 export type { CreateGroupPayload, CareGroupInfo, CreateGroupResponse };

--- a/src/types/group.ts
+++ b/src/types/group.ts
@@ -1,0 +1,35 @@
+type CreateGroupPayload = {
+  recipientName: string;
+  recipientGender: string;
+  recipientBirthDate: string;
+};
+
+type CareGroupInfo = {
+  id: string;
+  name: string;
+  recipientName: string;
+  recipientGender: string;
+  recipientBirthDate: string;
+  description: string;
+  healthStatus: string;
+  inviteCode: string;
+  createdAt: string;
+  memberCount: number;
+};
+
+type Pagination = {
+  totalCount: number;
+  totalPages: number;
+  currentPage: number;
+  pageSize: number;
+};
+
+type CreateGroupResponse = {
+  success: boolean;
+  message: string;
+  data: CareGroupInfo;
+  traceId: string;
+  pagination: Pagination;
+};
+
+export type { CreateGroupPayload, CareGroupInfo, CreateGroupResponse };


### PR DESCRIPTION
  - Add create group request and response types
  - Add create group API endpoint
  - Add useCreateGroup hook for create group submission flow
  - Connect GroupEntryDrawer to the create group API
  - Submit recipientName, recipientGender, and recipientBirthDate from group entry
  - Update birth date format to YYYY-MM-DD for API payload compatibility
  - Add loading state to the create group submit button
  - Show API error messages for invalid input and unauthorized requests
  - Store the created group id in localStorage as currentGroupId