### PR TITLE
Feature/money-split

### DIFF
--- a/src/api/endpoints/money.ts
+++ b/src/api/endpoints/money.ts
@@ -2,7 +2,12 @@ import type {
   CreateMoneyItemPayLoad,
   GetMoneyItemsParams,
   GetMoneyItemsResponse,
+  MemberTotalsParams,
+  MemberTotalsResponse,
   MoneyItemResponse,
+  SplitMoneyPayload,
+  SplitPreviewResponse,
+  SplitResponse,
   UpdateMoneyItemPayLoad,
 } from '@/types/money';
 
@@ -38,5 +43,30 @@ const updateMoneyItem = (
 const deleteMoneyItem = (careGroupId: string, expenseId: string) =>
   apiClient.delete(buildMoneyItemPath(careGroupId, expenseId));
 
+const splitPreview = (careGroupId: string, payload: SplitMoneyPayload) =>
+  apiClient.post<SplitPreviewResponse>(
+    `${buildMoneyItemsPath(careGroupId)}/split-preview`,
+    payload,
+  );
 
-export { getMoneyItems, createMoneyItem, updateMoneyItem, deleteMoneyItem };
+const splitMoneyItems = (careGroupId: string, payload: SplitMoneyPayload) =>
+  apiClient.post<SplitResponse>(
+    `${buildMoneyItemsPath(careGroupId)}/split`,
+    payload,
+  );
+
+const getMemberTotals = (careGroupId: string, params?: MemberTotalsParams) =>
+  apiClient.get<MemberTotalsResponse>(
+    `${buildMoneyItemsPath(careGroupId)}/member-totals`,
+    { params },
+  );
+
+export {
+  getMoneyItems,
+  createMoneyItem,
+  updateMoneyItem,
+  deleteMoneyItem,
+  splitPreview,
+  splitMoneyItems,
+  getMemberTotals,
+};

--- a/src/components/common/voiceCTA.tsx
+++ b/src/components/common/voiceCTA.tsx
@@ -43,7 +43,7 @@ export default function VoiceCTA({
           </div>
           <button
             type="button"
-            className="font-label-md inline-flex h-10 min-w-24 items-center justify-center rounded-full bg-neutral-800 px-4 text-neutral-50"
+            className="font-label-md inline-flex h-10 w-20 items-center justify-center rounded-full bg-neutral-800 px-4 text-neutral-50"
             onClick={() => {
               onClose();
               onInputClick();

--- a/src/features/money/components/CardsList.tsx
+++ b/src/features/money/components/CardsList.tsx
@@ -36,8 +36,7 @@ const formatDateLabel = (date: string) => date.replace(/-/g, '.');
 const groupByDate = (items: ExpenseItem[]): DateGroup[] => {
   const sorted = [...items].sort(
     (a, b) =>
-      parseISO(b.expenseDate.replace('Z', '')).getTime() -
-      parseISO(a.expenseDate.replace('Z', '')).getTime(),
+      parseISO(b.expenseDate).getTime() - parseISO(a.expenseDate).getTime(),
   );
   return sorted.reduce<DateGroup[]>((acc, item) => {
     const dateKey = item.expenseDate.slice(0, 10);

--- a/src/features/money/components/CreateDataCard.tsx
+++ b/src/features/money/components/CreateDataCard.tsx
@@ -13,18 +13,14 @@ import { createEmptyMoneyDraft } from '@/features/voice/services/moneyParser';
 
 type CreateDataCardProps = {
   onClose: () => void;
+  onSuccess: () => void;
   onVoiceInput?: () => void;
   initialDate?: Date;
 };
 
-type ResultModal = {
-  open: boolean;
-  variant: 'success' | 'error';
-  message?: string;
-};
-
 function CreateDataCard({
   onClose,
+  onSuccess,
   onVoiceInput,
   initialDate,
 }: CreateDataCardProps) {
@@ -38,10 +34,10 @@ function CreateDataCard({
     };
   });
 
-  const [resultModal, setResultModal] = useState<ResultModal>({
-    open: false,
-    variant: 'success',
-  });
+  const [errorModal, setErrorModal] = useState<{
+    open: boolean;
+    message?: string;
+  }>({ open: false });
 
   const { isLoading, handleCreateMoneyItem } = useCreateMoneyItem();
 
@@ -58,16 +54,11 @@ function CreateDataCard({
   const handleSubmit = async (event: React.SubmitEvent) => {
     event.preventDefault();
     const result = await handleCreateMoneyItem(draft);
-    setResultModal({
-      open: true,
-      variant: result.success ? 'success' : 'error',
-      message: result.success ? undefined : result.message,
-    });
-  };
-
-  const handleModalClose = () => {
-    setResultModal((prev) => ({ ...prev, open: false }));
-    if (resultModal.variant === 'success') onClose();
+    if (result.success) {
+      onSuccess();
+    } else {
+      setErrorModal({ open: true, message: result.message });
+    }
   };
 
   return (
@@ -105,17 +96,12 @@ function CreateDataCard({
       </form>
 
       <Modal
-        open={resultModal.open}
-        variant={resultModal.variant}
-        title={
-          resultModal.variant === 'success'
-            ? '帳目建立完成！'
-            : '帳目建立失敗！'
-        }
-        description={resultModal.message}
+        open={errorModal.open}
+        variant="error"
+        title="帳目建立失敗！"
+        description={errorModal.message}
         statusLayout="icon-first"
-        autoCloseMs={resultModal.variant === 'success' ? 1500 : undefined}
-        onClose={handleModalClose}
+        onClose={() => setErrorModal({ open: false })}
       />
     </>
   );

--- a/src/features/money/components/DailyContent.tsx
+++ b/src/features/money/components/DailyContent.tsx
@@ -14,9 +14,12 @@ import useSelectedDate from '@/features/money/hooks/useSelectedDate';
 import type { CategoryWithAmount } from '@/features/money/types';
 import cn from '@/lib/utils';
 
+import SplitDialog from './SplitDialog';
+
 function DailyContent() {
   const { selectedDate, setSelectedDate } = useSelectedDate();
   const [visibleMonth, setVisibleMonth] = useState<Date>(selectedDate);
+  const [splitDialogOpen, setSplitDialogOpen] = useState(false);
   const visibleMonthStr = format(visibleMonth, 'yyyy-MM');
   const { expenses } = useExpenses(visibleMonthStr);
 
@@ -113,7 +116,20 @@ function DailyContent() {
         )}
       </div>
 
-      <RoundedButtonPrimary className="mt-4">當日分帳</RoundedButtonPrimary>
+      <RoundedButtonPrimary
+        className="mt-4"
+        disabled={dailyTotal === 0}
+        onClick={() => setSplitDialogOpen(true)}
+      >
+        當日分帳
+      </RoundedButtonPrimary>
+
+      <SplitDialog
+        open={splitDialogOpen}
+        onOpenChange={setSplitDialogOpen}
+        scope="daily"
+        onConfirm={() => setSplitDialogOpen(false)}
+      />
     </div>
   );
 }

--- a/src/features/money/components/DailyContent.tsx
+++ b/src/features/money/components/DailyContent.tsx
@@ -4,6 +4,7 @@ import { format, parseISO } from 'date-fns';
 import { zhTW } from 'date-fns/locale';
 
 import Calendar from '@/components/common/Calendar';
+import Modal from '@/components/common/Modal';
 import { RoundedButtonPrimary } from '@/components/common/RoundedButtons';
 import {
   EXPENSE_CATEGORY_CONFIGS,
@@ -20,6 +21,7 @@ function DailyContent() {
   const { selectedDate, setSelectedDate } = useSelectedDate();
   const [visibleMonth, setVisibleMonth] = useState<Date>(selectedDate);
   const [splitDialogOpen, setSplitDialogOpen] = useState(false);
+  const [splitSuccessOpen, setSplitSuccessOpen] = useState(false);
   const visibleMonthStr = format(visibleMonth, 'yyyy-MM');
   const { expenses } = useExpenses(visibleMonthStr);
 
@@ -128,7 +130,19 @@ function DailyContent() {
         open={splitDialogOpen}
         onOpenChange={setSplitDialogOpen}
         scope="daily"
-        onConfirm={() => setSplitDialogOpen(false)}
+        onSuccess={() => {
+          setSplitDialogOpen(false);
+          setSplitSuccessOpen(true);
+        }}
+      />
+
+      <Modal
+        open={splitSuccessOpen}
+        variant="success"
+        title="分帳完成！"
+        statusLayout="icon-first"
+        autoCloseMs={1500}
+        onClose={() => setSplitSuccessOpen(false)}
       />
     </div>
   );

--- a/src/features/money/components/DailyContent.tsx
+++ b/src/features/money/components/DailyContent.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react';
 
-import { format } from 'date-fns';
+import { format, parseISO } from 'date-fns';
 import { zhTW } from 'date-fns/locale';
 
 import Calendar from '@/components/common/Calendar';
@@ -24,7 +24,7 @@ function DailyContent() {
   const { expenses } = useExpenses(visibleMonthStr);
 
   const markedDates = useMemo(
-    () => expenses.map((e) => new Date(e.expenseDate.replace('Z', ''))),
+    () => expenses.map((e) => parseISO(e.expenseDate)),
     [expenses],
   );
 

--- a/src/features/money/components/DailyContent.tsx
+++ b/src/features/money/components/DailyContent.tsx
@@ -120,7 +120,7 @@ function DailyContent() {
 
       <RoundedButtonPrimary
         className="mt-4"
-        disabled={dailyTotal === 0}
+        disabled={dailyExpenses.every((e) => e.splitStatus !== 'pending')}
         onClick={() => setSplitDialogOpen(true)}
       >
         當日分帳

--- a/src/features/money/components/EntryCard.tsx
+++ b/src/features/money/components/EntryCard.tsx
@@ -32,6 +32,7 @@ function EntryCard({ item }: { item: ExpenseItem }) {
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [dialogOpen, setDialogOpen] = useState(false);
   const [updateOpen, setUpdateOpen] = useState(false);
+  const [updateSuccessOpen, setUpdateSuccessOpen] = useState(false);
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [errorMessage, setErrorMessage] = useState('');
   const [showError, setShowError] = useState(false);
@@ -124,6 +125,10 @@ function EntryCard({ item }: { item: ExpenseItem }) {
             <UpdateDataCard
               item={item}
               onClose={() => setUpdateOpen(false)}
+              onSuccess={() => {
+                setUpdateOpen(false);
+                setUpdateSuccessOpen(true);
+              }}
               onDeleteClick={handleDeleteClick}
             />
           </AlertDialogPopup>
@@ -156,6 +161,15 @@ function EntryCard({ item }: { item: ExpenseItem }) {
         title="刪除失敗"
         description={errorMessage}
         onClose={() => setShowError(false)}
+      />
+
+      <Modal
+        open={updateSuccessOpen}
+        variant="success"
+        title="帳目更新完成！"
+        statusLayout="icon-first"
+        autoCloseMs={1500}
+        onClose={() => setUpdateSuccessOpen(false)}
       />
     </>
   );

--- a/src/features/money/components/ItemDetails.tsx
+++ b/src/features/money/components/ItemDetails.tsx
@@ -1,4 +1,4 @@
-import { format } from 'date-fns';
+import { format, parseISO } from 'date-fns';
 import { X } from 'lucide-react';
 
 import getAvatarSrcByKey from '@/assets/images/avatars';
@@ -25,10 +25,7 @@ function ItemDetails({ item }: { item: ExpenseItem }) {
   const creator = groupMembers.find((m) => m.userId === item.createdBy);
 
   const hashColor = SPLIT_HASH_COLOR[item.splitStatus] ?? 'text-neutral-900';
-  const displayDate = format(
-    new Date(item.expenseDate.replace('Z', '')),
-    'yyyy/MM/dd HH:mm',
-  );
+  const displayDate = format(parseISO(item.expenseDate), 'yyyy/MM/dd HH:mm');
 
   return (
     <div>

--- a/src/features/money/components/MemberExpenseSummary.tsx
+++ b/src/features/money/components/MemberExpenseSummary.tsx
@@ -1,40 +1,26 @@
 import getAvatarSrcByKey from '@/assets/images/avatars';
 import SingleAvatar from '@/components/common/SingleAvatar';
-import useGetGroupMembers from '@/features/groups/hooks/useGetGroupMembers';
-import type { ExpenseItem } from '@/features/money/types';
-import useCurrentGroupId from '@/hooks/useCurrentGroupID';
+import useMemberTotals from '@/features/money/hooks/useMemberTotals';
 
-type MemberExpenseSummaryProps = {
-  expenses: ExpenseItem[];
-};
+function MemberExpenseSummary() {
+  const { members } = useMemberTotals();
 
-function MemberExpenseSummary({ expenses }: MemberExpenseSummaryProps) {
-  const { currentGroupId } = useCurrentGroupId();
-  const { data: groupMembers = [] } = useGetGroupMembers(currentGroupId);
-
-  const membersWithTotals = groupMembers.map((member) => {
-    const total = expenses
-      .filter((e) => e.createdBy === member.userId)
-      .reduce((sum, e) => sum + e.amount, 0);
-    return { ...member, total };
-  });
-
-  if (membersWithTotals.length === 0) return null;
+  if (members.length === 0) return null;
 
   return (
     <section className="flex w-full flex-col gap-3 bg-neutral-800 px-6 py-5">
       <h3 className="font-heading-md text-neutral-50">各成員累積花費</h3>
       <ul className="font-paragraph-sm grid grid-cols-4 gap-x-4 gap-y-5 py-3 text-neutral-50">
-        {membersWithTotals.map((member) => (
-          <li key={member.userId} className="flex flex-col items-center gap-2">
+        {members.map(({ userId, name, avatarUrl, totalAmount }) => (
+          <li key={userId} className="flex flex-col items-center gap-2">
             <SingleAvatar
-              src={getAvatarSrcByKey(member.avatarKey)}
-              name={member.username}
+              src={getAvatarSrcByKey(avatarUrl ?? '')}
+              name={name}
               className="size-15 ring-neutral-900"
             />
             <div className="flex flex-col items-center">
-              <p>{member.username}</p>
-              <p>${member.total.toLocaleString()}</p>
+              <p>{name}</p>
+              <p>${totalAmount.toLocaleString()}</p>
             </div>
           </li>
         ))}

--- a/src/features/money/components/MonthlyContent.tsx
+++ b/src/features/money/components/MonthlyContent.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 
 import getAvatarSrcByKey from '@/assets/images/avatars';
 import FilterDropdownButton from '@/components/common/FilterDropdownButton';
+import Modal from '@/components/common/Modal';
 import { RoundedButtonPrimary } from '@/components/common/RoundedButtons';
 import SingleAvatar from '@/components/common/SingleAvatar';
 import UserGroup from '@/components/common/UserGroup';
@@ -33,6 +34,7 @@ function calculateCategoryTotals(expenses: ExpenseItem[]): CategoryTotals {
 
 function MonthlyContent() {
   const [splitDialogOpen, setSplitDialogOpen] = useState(false);
+  const [splitSuccessOpen, setSplitSuccessOpen] = useState(false);
   const { selectedMonth, setSelectedMonth } = useSelectedMonth();
   const { expenses } = useExpenses(selectedMonth);
   const { currentGroupId } = useCurrentGroupId();
@@ -121,7 +123,19 @@ function MonthlyContent() {
         open={splitDialogOpen}
         onOpenChange={setSplitDialogOpen}
         scope="monthly"
-        onConfirm={() => setSplitDialogOpen(false)}
+        onSuccess={() => {
+          setSplitDialogOpen(false);
+          setSplitSuccessOpen(true);
+        }}
+      />
+
+      <Modal
+        open={splitSuccessOpen}
+        variant="success"
+        title="分帳完成！"
+        statusLayout="icon-first"
+        autoCloseMs={1500}
+        onClose={() => setSplitSuccessOpen(false)}
       />
     </div>
   );

--- a/src/features/money/components/MonthlyContent.tsx
+++ b/src/features/money/components/MonthlyContent.tsx
@@ -113,7 +113,7 @@ function MonthlyContent() {
       </ul>
 
       <RoundedButtonPrimary
-        disabled={monthlyTotal === 0}
+        disabled={expenses.every((e) => e.splitStatus !== 'pending')}
         onClick={() => setSplitDialogOpen(true)}
       >
         一鍵分帳

--- a/src/features/money/components/MonthlyContent.tsx
+++ b/src/features/money/components/MonthlyContent.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+
 import getAvatarSrcByKey from '@/assets/images/avatars';
 import FilterDropdownButton from '@/components/common/FilterDropdownButton';
 import { RoundedButtonPrimary } from '@/components/common/RoundedButtons';
@@ -19,6 +21,8 @@ import cn from '@/lib/utils';
 import useExpenses from '../hooks/useExpenses';
 import useSelectedMonth, { MONTH_OPTIONS } from '../hooks/useSelectedMonth';
 
+import SplitDialog from './SplitDialog';
+
 function calculateCategoryTotals(expenses: ExpenseItem[]): CategoryTotals {
   const totals = { ...INITIAL_CATEGORY_TOTALS };
   expenses.forEach((expense) => {
@@ -28,6 +32,7 @@ function calculateCategoryTotals(expenses: ExpenseItem[]): CategoryTotals {
 }
 
 function MonthlyContent() {
+  const [splitDialogOpen, setSplitDialogOpen] = useState(false);
   const { selectedMonth, setSelectedMonth } = useSelectedMonth();
   const { expenses } = useExpenses(selectedMonth);
   const { currentGroupId } = useCurrentGroupId();
@@ -105,7 +110,19 @@ function MonthlyContent() {
         ))}
       </ul>
 
-      <RoundedButtonPrimary onClick={() => {}}>一鍵分帳</RoundedButtonPrimary>
+      <RoundedButtonPrimary
+        disabled={monthlyTotal === 0}
+        onClick={() => setSplitDialogOpen(true)}
+      >
+        一鍵分帳
+      </RoundedButtonPrimary>
+
+      <SplitDialog
+        open={splitDialogOpen}
+        onOpenChange={setSplitDialogOpen}
+        scope="monthly"
+        onConfirm={() => setSplitDialogOpen(false)}
+      />
     </div>
   );
 }

--- a/src/features/money/components/SplitDialog.tsx
+++ b/src/features/money/components/SplitDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import { X } from 'lucide-react';
 
@@ -48,14 +48,18 @@ function SplitDialog({
   const { isLoading: isSubmitting, handleSubmitSplit } = useSubmitSplit();
 
   const expenses = scope === 'daily' ? dailyExpenses : monthlyExpenses;
-  const pendingItems = expenses
-    .filter(({ splitStatus }) => splitStatus === 'pending')
-    .map(({ id, title, amount, createdBy }) => ({
-      id,
-      title,
-      amount,
-      createdBy,
-    }));
+  const pendingItems = useMemo(
+    () =>
+      expenses
+        .filter(({ splitStatus }) => splitStatus === 'pending')
+        .map(({ id, title, amount, createdBy }) => ({
+          id,
+          title,
+          amount,
+          createdBy,
+        })),
+    [expenses],
+  );
 
   const [step, setStep] = useState<'select' | 'preview'>('select');
   const [selectedItemIds, setSelectedItemIds] = useState<string[]>([]);
@@ -66,16 +70,23 @@ function SplitDialog({
     open: boolean;
     message?: string;
   }>({ open: false });
+  const [isInitialized, setIsInitialized] = useState(false);
 
   useEffect(() => {
-    if (!open) return;
-    setSelectedItemIds(pendingItems.map(({ id }) => id));
-    setSelectedMemberIds(members.map(({ userId }) => userId));
-    setStep('select');
-    setPreviewData(null);
-    setPreviewError(null);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open]);
+    if (!open) {
+      setIsInitialized(false);
+      setStep('select');
+      setPreviewData(null);
+      setPreviewError(null);
+      return;
+    }
+
+    if (!isInitialized && pendingItems.length > 0 && members.length > 0) {
+      setSelectedItemIds(pendingItems.map(({ id }) => id));
+      setSelectedMemberIds(members.map(({ userId }) => userId));
+      setIsInitialized(true);
+    }
+  }, [open, isInitialized, pendingItems, members]);
 
   const handleGoToPreview = async () => {
     setPreviewError(null);

--- a/src/features/money/components/SplitDialog.tsx
+++ b/src/features/money/components/SplitDialog.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 
 import { X } from 'lucide-react';
 
+import Modal from '@/components/common/Modal';
 import { RoundedButtonPrimary } from '@/components/common/RoundedButtons';
 import {
   AlertDialog,
@@ -12,7 +13,9 @@ import {
 } from '@/components/ui/alert-dialog';
 import useGetGroupMembers from '@/features/groups/hooks/useGetGroupMembers';
 import useActiveExpenses from '@/features/money/hooks/useActiveExpenses';
-import useSplitPreview from '@/features/money/hooks/useSplitPreview';
+import useFetchSplitPreview from '@/features/money/hooks/useFetchSplitPreview';
+import useSubmitSplit from '@/features/money/hooks/useSubmitSplit';
+import type { MemberSplit, SplitItem } from '@/features/money/types';
 import useCurrentGroupId from '@/hooks/useCurrentGroupID';
 
 import SplitItemsPreview from './SplitItemsPreview';
@@ -24,18 +27,25 @@ type SplitDialogProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   scope: 'daily' | 'monthly';
-  onConfirm: (selectedItemIds: string[], selectedMemberIds: string[]) => void;
+  onSuccess: () => void;
+};
+
+type PreviewData = {
+  selectedItems: SplitItem[];
+  memberSplits: MemberSplit[];
 };
 
 function SplitDialog({
   open,
   onOpenChange,
   scope,
-  onConfirm,
+  onSuccess,
 }: SplitDialogProps) {
   const { currentGroupId } = useCurrentGroupId();
   const { dailyExpenses, monthlyExpenses } = useActiveExpenses();
   const { data: members = [] } = useGetGroupMembers(currentGroupId);
+  const { isLoading: isPreviewing, fetchPreview } = useFetchSplitPreview();
+  const { isLoading: isSubmitting, handleSubmitSplit } = useSubmitSplit();
 
   const expenses = scope === 'daily' ? dailyExpenses : monthlyExpenses;
   const pendingItems = expenses
@@ -50,24 +60,44 @@ function SplitDialog({
   const [step, setStep] = useState<'select' | 'preview'>('select');
   const [selectedItemIds, setSelectedItemIds] = useState<string[]>([]);
   const [selectedMemberIds, setSelectedMemberIds] = useState<string[]>([]);
+  const [previewData, setPreviewData] = useState<PreviewData | null>(null);
+  const [previewError, setPreviewError] = useState<string | null>(null);
+  const [errorModal, setErrorModal] = useState<{
+    open: boolean;
+    message?: string;
+  }>({ open: false });
 
   useEffect(() => {
     if (!open) return;
     setSelectedItemIds(pendingItems.map(({ id }) => id));
     setSelectedMemberIds(members.map(({ userId }) => userId));
     setStep('select');
+    setPreviewData(null);
+    setPreviewError(null);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open]);
 
-  const { selectedItems, memberSplits } = useSplitPreview(
-    selectedItemIds,
-    selectedMemberIds,
-    pendingItems,
-    members,
-  );
+  const handleGoToPreview = async () => {
+    setPreviewError(null);
+    const result = await fetchPreview(selectedItemIds, selectedMemberIds);
+    if (result.success) {
+      setPreviewData({
+        selectedItems: result.selectedItems,
+        memberSplits: result.memberSplits,
+      });
+      setStep('preview');
+    } else {
+      setPreviewError(result.message);
+    }
+  };
 
-  const handleConfirm = () => {
-    onConfirm(selectedItemIds, selectedMemberIds);
+  const handleConfirm = async () => {
+    const result = await handleSubmitSplit(selectedItemIds, selectedMemberIds);
+    if (result.success) {
+      onSuccess();
+    } else {
+      setErrorModal({ open: true, message: result.message });
+    }
   };
 
   return (
@@ -114,25 +144,40 @@ function SplitDialog({
                 </div>
               </>
             ) : (
-              <>
-                <SplitItemsPreview items={selectedItems} />
-                <SplitResultPreview memberSplits={memberSplits} />
-              </>
+              previewData && (
+                <>
+                  <SplitItemsPreview items={previewData.selectedItems} />
+                  <SplitResultPreview memberSplits={previewData.memberSplits} />
+                </>
+              )
             )}
           </div>
 
           {step === 'select' ? (
-            <RoundedButtonPrimary
-              className="h-[45.6px] w-full rounded-full bg-neutral-900 text-neutral-50"
-              onClick={() => setStep('preview')}
-            >
-              確認分帳結果
-            </RoundedButtonPrimary>
+            <div className="flex flex-col gap-2">
+              {previewError && (
+                <p className="font-paragraph-sm text-center text-red-500">
+                  {previewError}
+                </p>
+              )}
+              <RoundedButtonPrimary
+                className="h-[45.6px] w-full rounded-full bg-neutral-900 text-neutral-50"
+                onClick={handleGoToPreview}
+                disabled={
+                  isPreviewing ||
+                  selectedItemIds.length === 0 ||
+                  selectedMemberIds.length === 0
+                }
+              >
+                {isPreviewing ? '計算中...' : '確認分帳結果'}
+              </RoundedButtonPrimary>
+            </div>
           ) : (
             <div className="flex h-10 items-center justify-between gap-2">
               <RoundedButtonPrimary
                 onClick={() => setStep('select')}
                 className="h-9 flex-1 bg-transparent px-0 text-neutral-900 ring-2 ring-neutral-900"
+                disabled={isSubmitting}
               >
                 取消
               </RoundedButtonPrimary>
@@ -140,11 +185,21 @@ function SplitDialog({
               <RoundedButtonPrimary
                 className="h-full flex-1 bg-neutral-900 px-0 text-neutral-50"
                 onClick={handleConfirm}
+                disabled={isSubmitting}
               >
-                確定分帳
+                {isSubmitting ? '處理中...' : '確定分帳'}
               </RoundedButtonPrimary>
             </div>
           )}
+
+          <Modal
+            open={errorModal.open}
+            variant="error"
+            title="分帳失敗！"
+            description={errorModal.message}
+            statusLayout="icon-first"
+            onClose={() => setErrorModal({ open: false })}
+          />
         </AlertDialogPopup>
       </AlertDialogPortal>
     </AlertDialog>

--- a/src/features/money/components/SplitDialog.tsx
+++ b/src/features/money/components/SplitDialog.tsx
@@ -1,0 +1,154 @@
+import { useEffect, useState } from 'react';
+
+import { X } from 'lucide-react';
+
+import { RoundedButtonPrimary } from '@/components/common/RoundedButtons';
+import {
+  AlertDialog,
+  AlertDialogBackdrop,
+  AlertDialogClose,
+  AlertDialogPopup,
+  AlertDialogPortal,
+} from '@/components/ui/alert-dialog';
+import useGetGroupMembers from '@/features/groups/hooks/useGetGroupMembers';
+import useActiveExpenses from '@/features/money/hooks/useActiveExpenses';
+import useSplitPreview from '@/features/money/hooks/useSplitPreview';
+import useCurrentGroupId from '@/hooks/useCurrentGroupID';
+
+import SplitItemsPreview from './SplitItemsPreview';
+import SplitItemsSelector from './SplitItemsSelector';
+import { SplitParticipantSelect } from './SplitParticipant';
+import SplitResultPreview from './SplitResultPreview';
+
+type SplitDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  scope: 'daily' | 'monthly';
+  onConfirm: (selectedItemIds: string[], selectedMemberIds: string[]) => void;
+};
+
+function SplitDialog({
+  open,
+  onOpenChange,
+  scope,
+  onConfirm,
+}: SplitDialogProps) {
+  const { currentGroupId } = useCurrentGroupId();
+  const { dailyExpenses, monthlyExpenses } = useActiveExpenses();
+  const { data: members = [] } = useGetGroupMembers(currentGroupId);
+
+  const expenses = scope === 'daily' ? dailyExpenses : monthlyExpenses;
+  const pendingItems = expenses
+    .filter(({ splitStatus }) => splitStatus === 'pending')
+    .map(({ id, title, amount, createdBy }) => ({
+      id,
+      title,
+      amount,
+      createdBy,
+    }));
+
+  const [step, setStep] = useState<'select' | 'preview'>('select');
+  const [selectedItemIds, setSelectedItemIds] = useState<string[]>([]);
+  const [selectedMemberIds, setSelectedMemberIds] = useState<string[]>([]);
+
+  useEffect(() => {
+    if (!open) return;
+    setSelectedItemIds(pendingItems.map(({ id }) => id));
+    setSelectedMemberIds(members.map(({ userId }) => userId));
+    setStep('select');
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  const { selectedItems, memberSplits } = useSplitPreview(
+    selectedItemIds,
+    selectedMemberIds,
+    pendingItems,
+    members,
+  );
+
+  const handleConfirm = () => {
+    onConfirm(selectedItemIds, selectedMemberIds);
+  };
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogPortal>
+        <AlertDialogBackdrop />
+        <AlertDialogPopup className="h-95vh flex w-92.25 flex-col rounded-sm border-0 bg-neutral-200 px-6 pt-3 pb-5">
+          <AlertDialogClose
+            className="absolute top-4 right-6 flex size-7 items-center justify-center rounded-full text-neutral-900"
+            aria-label="關閉"
+          >
+            <X className="size-4" strokeWidth={3} />
+          </AlertDialogClose>
+
+          <div className="flex flex-1 flex-col gap-4 overflow-y-auto pt-7">
+            {step === 'select' ? (
+              <>
+                <SplitItemsSelector
+                  items={pendingItems}
+                  selectedIds={selectedItemIds}
+                  onSelectedIdsChange={setSelectedItemIds}
+                />
+
+                <div className="flex flex-col pb-5">
+                  <p className="font-heading-sm pb-3 text-neutral-900">
+                    選擇平分對象
+                  </p>
+
+                  {members.map(({ userId, username, avatarKey }) => (
+                    <SplitParticipantSelect
+                      key={userId}
+                      name={username}
+                      avatarKey={avatarKey}
+                      selected={selectedMemberIds.includes(userId)}
+                      onToggle={() =>
+                        setSelectedMemberIds((prev) =>
+                          prev.includes(userId)
+                            ? prev.filter((id) => id !== userId)
+                            : [...prev, userId],
+                        )
+                      }
+                    />
+                  ))}
+                </div>
+              </>
+            ) : (
+              <>
+                <SplitItemsPreview items={selectedItems} />
+                <SplitResultPreview memberSplits={memberSplits} />
+              </>
+            )}
+          </div>
+
+          {step === 'select' ? (
+            <RoundedButtonPrimary
+              className="h-[45.6px] w-full rounded-full bg-neutral-900 text-neutral-50"
+              onClick={() => setStep('preview')}
+            >
+              確認分帳結果
+            </RoundedButtonPrimary>
+          ) : (
+            <div className="flex h-10 items-center justify-between gap-2">
+              <RoundedButtonPrimary
+                onClick={() => setStep('select')}
+                className="h-9 flex-1 bg-transparent px-0 text-neutral-900 ring-2 ring-neutral-900"
+              >
+                取消
+              </RoundedButtonPrimary>
+
+              <RoundedButtonPrimary
+                className="h-full flex-1 bg-neutral-900 px-0 text-neutral-50"
+                onClick={handleConfirm}
+              >
+                確定分帳
+              </RoundedButtonPrimary>
+            </div>
+          )}
+        </AlertDialogPopup>
+      </AlertDialogPortal>
+    </AlertDialog>
+  );
+}
+
+export default SplitDialog;

--- a/src/features/money/components/SplitItemCard.tsx
+++ b/src/features/money/components/SplitItemCard.tsx
@@ -1,0 +1,56 @@
+import { Check } from 'lucide-react';
+
+import cn from '@/lib/utils';
+
+type SplitItemCardProps = {
+  title: string;
+  amount: number;
+  checked: boolean;
+  readOnly?: boolean;
+  onChange?: (checked: boolean) => void;
+};
+
+function SplitItemCard({
+  title,
+  amount,
+  checked,
+  readOnly = false,
+  onChange,
+}: SplitItemCardProps) {
+  const content = (
+    <div className="flex w-full items-center justify-between">
+      <p className="font-paragraph-lg text-neutral-900">{title}</p>
+      <p className="font-label-lg w-fit min-w-17 text-right text-neutral-900">
+        $ {amount.toLocaleString()}
+      </p>
+    </div>
+  );
+
+  if (readOnly) {
+    return (
+      <div className="flex h-fit min-h-15.5 w-full items-center rounded-sm border-2 border-neutral-900 bg-neutral-100 px-7 py-4">
+        {content}
+      </div>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      className="flex h-fit min-h-15.5 w-full items-center justify-between gap-3 rounded-sm border-2 border-neutral-900 bg-neutral-100 px-7 py-4 text-left"
+      onClick={() => onChange?.(!checked)}
+    >
+      <div
+        className={cn(
+          'flex size-6 shrink-0 items-center justify-center rounded-full',
+          checked ? 'bg-primary-default' : 'bg-neutral-400',
+        )}
+      >
+        <Check className="size-2.5 text-white" strokeWidth={4.5} />
+      </div>
+      {content}
+    </button>
+  );
+}
+
+export default SplitItemCard;

--- a/src/features/money/components/SplitItemsPreview.tsx
+++ b/src/features/money/components/SplitItemsPreview.tsx
@@ -1,0 +1,39 @@
+import type { SplitItem } from '@/features/money/types';
+
+import SplitItemCard from './SplitItemCard';
+
+type SplitItemsPreviewProps = {
+  items: SplitItem[];
+};
+
+function SplitItemsPreview({ items }: SplitItemsPreviewProps) {
+  const totalAmount = items.reduce((sum, { amount }) => sum + amount, 0);
+
+  return (
+    <div className="flex flex-col gap-3 border-b-2 border-neutral-900 pb-3">
+      <p className="font-heading-sm text-neutral-900">平分項目</p>
+
+      <div className="flex h-50.5 flex-col gap-2 overflow-y-auto">
+        {items.map(({ id, title, amount }) => (
+          <SplitItemCard
+            key={id}
+            title={title}
+            amount={amount}
+            checked
+            readOnly
+          />
+        ))}
+      </div>
+
+      <div className="flex items-baseline justify-end gap-3">
+        <p className="font-label-md text-neutral-700">共{items.length}筆帳目</p>
+        <p className="font-heading-md text-neutral-900">總計</p>
+        <p className="font-heading-md text-neutral-900">
+          $ {totalAmount.toLocaleString()}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export default SplitItemsPreview;

--- a/src/features/money/components/SplitItemsSelector.tsx
+++ b/src/features/money/components/SplitItemsSelector.tsx
@@ -1,0 +1,54 @@
+import type { SplitItem } from '@/features/money/types';
+
+import SplitItemCard from './SplitItemCard';
+
+type SplitItemsSelectorProps = {
+  items: SplitItem[];
+  selectedIds: string[];
+  onSelectedIdsChange: (ids: string[]) => void;
+};
+
+function SplitItemsSelector({
+  items,
+  selectedIds,
+  onSelectedIdsChange,
+}: SplitItemsSelectorProps) {
+  const total = items
+    .filter(({ id }) => selectedIds.includes(id))
+    .reduce((sum, { amount }) => sum + amount, 0);
+
+  const handleToggle = (id: string, checked: boolean) => {
+    if (checked) {
+      onSelectedIdsChange([...selectedIds, id]);
+    } else {
+      onSelectedIdsChange(selectedIds.filter((sid) => sid !== id));
+    }
+  };
+
+  return (
+    <div className="flex w-full flex-col gap-3 border-b-2 border-neutral-900 pb-3">
+      <p className="font-heading-sm text-neutral-900">選擇平分項目</p>
+
+      <div className="flex max-h-50.5 flex-col gap-2 overflow-y-auto">
+        {items.map(({ id, title, amount }) => (
+          <SplitItemCard
+            key={id}
+            title={title}
+            amount={amount}
+            checked={selectedIds.includes(id)}
+            onChange={(checked) => handleToggle(id, checked)}
+          />
+        ))}
+      </div>
+
+      <div className="flex items-baseline justify-end gap-3">
+        <p className="font-heading-md text-neutral-900">總計</p>
+        <p className="font-heading-md text-neutral-900">
+          $ {total.toLocaleString()}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export default SplitItemsSelector;

--- a/src/features/money/components/SplitParticipant.tsx
+++ b/src/features/money/components/SplitParticipant.tsx
@@ -1,0 +1,83 @@
+import { Check } from 'lucide-react';
+
+import getAvatarSrcByKey from '@/assets/images/avatars';
+import SingleAvatar from '@/components/common/SingleAvatar';
+import type { MemberSplit } from '@/features/money/types';
+import cn from '@/lib/utils';
+
+type SplitParticipantSelectProps = {
+  name: string;
+  avatarKey: string;
+  selected: boolean;
+  onToggle: () => void;
+};
+
+type SplitParticipantProps = Pick<
+  MemberSplit,
+  'status' | 'avatarKey' | 'amount'
+> & {
+  name: string;
+};
+
+function SplitParticipantSelect({
+  name,
+  avatarKey,
+  selected,
+  onToggle,
+}: SplitParticipantSelectProps) {
+  return (
+    <div className="flex h-14 items-center gap-3 px-3 py-2">
+      <SingleAvatar
+        src={getAvatarSrcByKey(avatarKey)}
+        name={name}
+        className="size-10 ring-neutral-900"
+      />
+
+      <span className="font-paragraph-md flex-1 text-neutral-900">{name}</span>
+
+      <button
+        type="button"
+        aria-label={selected ? '取消參與分帳' : '加入參與分帳'}
+        className={cn(
+          'flex size-6 items-center justify-center rounded-full transition-colors',
+          selected ? 'bg-primary-default' : 'bg-neutral-400',
+        )}
+        onClick={onToggle}
+      >
+        <Check className="size-2.5 text-white" strokeWidth={4.5} />
+      </button>
+    </div>
+  );
+}
+
+function SplitParticipant({
+  name,
+  avatarKey,
+  status,
+  amount,
+}: SplitParticipantProps) {
+  return (
+    <div className="flex items-center gap-4 px-3 py-2">
+      <SingleAvatar
+        src={getAvatarSrcByKey(avatarKey)}
+        name={name}
+        className="size-10 ring-neutral-900"
+      />
+
+      <p className="font-paragraph-md flex-1 text-neutral-900">{name}</p>
+
+      <p
+        className={cn(
+          'font-paragraph-md border-b-2 pb-0.5 text-neutral-900',
+          status === 'receivable'
+            ? 'border-primary-default'
+            : 'border-secondary-dark',
+        )}
+      >
+        {status === 'receivable' ? '應收' : '應付'} ${amount.toLocaleString()}
+      </p>
+    </div>
+  );
+}
+
+export { SplitParticipant, SplitParticipantSelect };

--- a/src/features/money/components/SplitResultPreview.tsx
+++ b/src/features/money/components/SplitResultPreview.tsx
@@ -1,0 +1,27 @@
+import type { MemberSplit } from '@/features/money/types';
+
+import { SplitParticipant } from './SplitParticipant';
+
+type SplitResultPreviewProps = {
+  memberSplits: MemberSplit[];
+};
+
+function SplitResultPreview({ memberSplits }: SplitResultPreviewProps) {
+  return (
+    <div className="flex flex-col pb-5">
+      <p className="font-heading-sm pb-3 text-neutral-900">預覽分帳結果</p>
+
+      {memberSplits.map(({ userId, username, avatarKey, status, amount }) => (
+        <SplitParticipant
+          key={userId}
+          name={username}
+          avatarKey={avatarKey}
+          status={status}
+          amount={amount}
+        />
+      ))}
+    </div>
+  );
+}
+
+export default SplitResultPreview;

--- a/src/features/money/components/UpdateDataCard.tsx
+++ b/src/features/money/components/UpdateDataCard.tsx
@@ -14,14 +14,9 @@ import type { ExpenseItem, MoneyDraft } from '@/features/money/types';
 type UpdateDataCardProps = {
   item: ExpenseItem;
   onClose: () => void;
+  onSuccess: () => void;
   onDeleteClick: () => void;
   onVoiceInput?: () => void;
-};
-
-type ResultModal = {
-  open: boolean;
-  variant: 'success' | 'error';
-  message?: string;
 };
 
 function itemToMoneyDraft(item: ExpenseItem): MoneyDraft {
@@ -42,14 +37,15 @@ function itemToMoneyDraft(item: ExpenseItem): MoneyDraft {
 function UpdateDataCard({
   item,
   onClose,
+  onSuccess,
   onDeleteClick,
   onVoiceInput,
 }: UpdateDataCardProps) {
   const [draft, setDraft] = useState<MoneyDraft>(() => itemToMoneyDraft(item));
-  const [resultModal, setResultModal] = useState<ResultModal>({
-    open: false,
-    variant: 'success',
-  });
+  const [errorModal, setErrorModal] = useState<{
+    open: boolean;
+    message?: string;
+  }>({ open: false });
 
   const { isLoading, handleUpdateMoneyItem } = useUpdateMoneyItem();
 
@@ -66,16 +62,11 @@ function UpdateDataCard({
   const handleSubmit = async (event: React.SubmitEvent) => {
     event.preventDefault();
     const result = await handleUpdateMoneyItem(item.id, draft, item.updatedAt);
-    setResultModal({
-      open: true,
-      variant: result.success ? 'success' : 'error',
-      message: result.success ? undefined : result.message,
-    });
-  };
-
-  const handleModalClose = () => {
-    setResultModal((prev) => ({ ...prev, open: false }));
-    if (resultModal.variant === 'success') onClose();
+    if (result.success) {
+      onSuccess();
+    } else {
+      setErrorModal({ open: true, message: result.message });
+    }
   };
 
   return (
@@ -125,17 +116,12 @@ function UpdateDataCard({
       </form>
 
       <Modal
-        open={resultModal.open}
-        variant={resultModal.variant}
-        title={
-          resultModal.variant === 'success'
-            ? '帳目更新完成！'
-            : '帳目更新失敗！'
-        }
-        description={resultModal.message}
+        open={errorModal.open}
+        variant="error"
+        title="帳目更新失敗！"
+        description={errorModal.message}
         statusLayout="icon-first"
-        autoCloseMs={resultModal.variant === 'success' ? 1500 : undefined}
-        onClose={handleModalClose}
+        onClose={() => setErrorModal({ open: false })}
       />
     </>
   );

--- a/src/features/money/components/UpdateDataCard.tsx
+++ b/src/features/money/components/UpdateDataCard.tsx
@@ -25,7 +25,7 @@ type ResultModal = {
 };
 
 function itemToMoneyDraft(item: ExpenseItem): MoneyDraft {
-  const date = parseISO(item.expenseDate.replace('Z', ''));
+  const date = parseISO(item.expenseDate);
   return {
     title: item.title,
     amount: String(item.amount),
@@ -88,17 +88,19 @@ function UpdateDataCard({
           contentClassName="p-0"
         >
           <DataFormCard.Content>
-            <VoiceCTA
-              className="bg-primary-default text-neutral-900"
-              title="記帳"
-              onClose={onClose}
-              onInputClick={() => onVoiceInput?.()}
-            />
-            <MoneyDataSmallForm
-              className="w-full border-0 bg-neutral-50 px-3 pt-3"
-              value={draft}
-              onChange={handleChange}
-            />
+            <div className="flex flex-col text-neutral-900">
+              <VoiceCTA
+                className="bg-primary-default text-neutral-900"
+                title="記帳"
+                onClose={onClose}
+                onInputClick={() => onVoiceInput?.()}
+              />
+              <MoneyDataSmallForm
+                className="w-full border-0 bg-neutral-50 px-3 pt-3"
+                value={draft}
+                onChange={handleChange}
+              />
+            </div>
           </DataFormCard.Content>
           <DataFormCard.Footer>
             <div className="flex gap-5">

--- a/src/features/money/hooks/useActiveExpenses.ts
+++ b/src/features/money/hooks/useActiveExpenses.ts
@@ -19,7 +19,7 @@ function useActiveExpenses() {
     useExpenses(dailyMonth);
   const selectedDateStr = format(selectedDate, 'yyyy-MM-dd');
   const dailyExpenses = dailyMonthExpenses.filter((e) =>
-    e.expenseDate.replace('Z', '').startsWith(selectedDateStr),
+    e.expenseDate.startsWith(selectedDateStr),
   );
 
   const cardListItems = activeTab === 'daily' ? dailyExpenses : monthlyExpenses;

--- a/src/features/money/hooks/useCreateMoneyItem.ts
+++ b/src/features/money/hooks/useCreateMoneyItem.ts
@@ -2,7 +2,7 @@ import { useState } from 'react';
 
 import { useQueryClient } from '@tanstack/react-query';
 import axios from 'axios';
-import { format, parse } from 'date-fns';
+import { formatISO, parse } from 'date-fns';
 
 import { createMoneyItem } from '@/api/endpoints/money';
 import { CURRENT_GROUP_ID_KEY } from '@/constants/auth';
@@ -23,13 +23,12 @@ function formatForPayload(draft: MoneyDraft): CreateMoneyItemPayLoad {
     'yyyy/MM/dd HH:mm',
     new Date(),
   );
-
   return {
     title: draft.title,
     amount: Number(draft.amount) || 0,
     category: draft.category ?? 'other',
     notes: draft.notes,
-    expenseDate: format(parsedDate, "yyyy-MM-dd'T'HH:mm"),
+    expenseDate: formatISO(parsedDate),
     splitStatus: draft.needsSplit ? 'pending' : 'none',
   };
 }

--- a/src/features/money/hooks/useCreateMoneyItem.ts
+++ b/src/features/money/hooks/useCreateMoneyItem.ts
@@ -29,7 +29,7 @@ function formatForPayload(draft: MoneyDraft): CreateMoneyItemPayLoad {
     amount: Number(draft.amount) || 0,
     category: draft.category ?? 'other',
     notes: draft.notes,
-    expenseDate: format(parsedDate, "yyyy-MM-dd'T'HH:mm:ss"),
+    expenseDate: format(parsedDate, "yyyy-MM-dd'T'HH:mm"),
     splitStatus: draft.needsSplit ? 'pending' : 'none',
   };
 }

--- a/src/features/money/hooks/useFetchSplitPreview.ts
+++ b/src/features/money/hooks/useFetchSplitPreview.ts
@@ -1,0 +1,85 @@
+import { useState } from 'react';
+
+import axios from 'axios';
+
+import { splitPreview } from '@/api/endpoints/money';
+import { CURRENT_GROUP_ID_KEY } from '@/constants/auth';
+import type { MemberSplit, SplitItem } from '@/features/money/types';
+import type { SplitDetail, SplitPreviewItem } from '@/types/money';
+
+type SplitPreviewResult =
+  | { success: true; selectedItems: SplitItem[]; memberSplits: MemberSplit[] }
+  | { success: false; message: string };
+
+const getCurrentCareGroupId = () =>
+  window.localStorage.getItem(CURRENT_GROUP_ID_KEY);
+
+function toSplitItem({ id, title, amount }: SplitPreviewItem): SplitItem {
+  return { id, title, amount };
+}
+
+function toMemberSplit({
+  userId,
+  name,
+  avatarUrl,
+  receivableAmount,
+  payableAmount,
+}: SplitDetail): MemberSplit {
+  return {
+    userId,
+    username: name,
+    avatarKey: avatarUrl,
+    status: receivableAmount > 0 ? 'receivable' : 'payable',
+    amount: receivableAmount > 0 ? receivableAmount : payableAmount,
+  };
+}
+
+function getErrorMessage(error: unknown): string {
+  if (axios.isAxiosError(error)) {
+    const message = error.response?.data?.message;
+    if (typeof message === 'string' && message.trim().length > 0) {
+      return message;
+    }
+  }
+  return '發生預期外的問題，請稍後再嘗試';
+}
+
+function useFetchSplitPreview() {
+  const [isLoading, setIsLoading] = useState(false);
+
+  const fetchPreview = async (
+    expenseIds: string[],
+    targetUserIds: string[],
+  ): Promise<SplitPreviewResult> => {
+    const careGroupId = getCurrentCareGroupId();
+
+    if (!careGroupId) {
+      return { success: false, message: '尚未選擇照護群組' };
+    }
+
+    setIsLoading(true);
+
+    try {
+      const res = await splitPreview(careGroupId, {
+        splitMode: 'custom',
+        expenseIds,
+        targetUserIds,
+      });
+
+      const { selectedExpenses, splitDetails } = res.data.data;
+      return {
+        success: true,
+        selectedItems: selectedExpenses.map(toSplitItem),
+        memberSplits: splitDetails.map(toMemberSplit),
+      };
+    } catch (error) {
+      return { success: false, message: getErrorMessage(error) };
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return { isLoading, fetchPreview };
+}
+
+export default useFetchSplitPreview;

--- a/src/features/money/hooks/useMemberTotals.ts
+++ b/src/features/money/hooks/useMemberTotals.ts
@@ -1,0 +1,44 @@
+import { useQuery } from '@tanstack/react-query';
+import { formatISO } from 'date-fns';
+import { toast } from 'sonner';
+
+import { getMemberTotals } from '@/api/endpoints/money';
+import { CURRENT_GROUP_ID_KEY } from '@/constants/auth';
+import useSelectedMonth from '@/features/money/hooks/useSelectedMonth';
+import moneyKeys from '@/features/money/queryKeys';
+
+const getCurrentCareGroupId = () =>
+  window.localStorage.getItem(CURRENT_GROUP_ID_KEY);
+
+function useMemberTotals() {
+  const careGroupId = getCurrentCareGroupId();
+  const { selectedMonth } = useSelectedMonth();
+
+  const targetDate = formatISO(new Date(`${selectedMonth}-01`));
+
+  const query = useQuery({
+    queryKey: moneyKeys.memberTotals(careGroupId ?? '', selectedMonth),
+    queryFn: async () => {
+      if (!careGroupId) return [];
+      try {
+        const response = await getMemberTotals(careGroupId, {
+          scope: 'monthly',
+          targetDate,
+          pendingOnly: false,
+        });
+        return response.data.data.members;
+      } catch {
+        toast.error('載入成員花費失敗');
+        return [];
+      }
+    },
+    enabled: !!careGroupId,
+  });
+
+  return {
+    ...query,
+    members: query.data ?? [],
+  };
+}
+
+export default useMemberTotals;

--- a/src/features/money/hooks/useSplitPreview.ts
+++ b/src/features/money/hooks/useSplitPreview.ts
@@ -1,0 +1,44 @@
+import type {
+  MemberSplit,
+  SplitMember,
+  SplitPendingItem,
+} from '@/features/money/types';
+
+function useSplitPreview(
+  selectedItemIds: string[],
+  selectedMemberIds: string[],
+  items: SplitPendingItem[],
+  members: SplitMember[],
+): { selectedItems: SplitPendingItem[]; memberSplits: MemberSplit[] } {
+  const selectedItems = items.filter(({ id }) => selectedItemIds.includes(id));
+  const selectedMembers = members.filter(({ userId }) =>
+    selectedMemberIds.includes(userId),
+  );
+
+  const totalAmount = selectedItems.reduce(
+    (sum, { amount }) => sum + amount,
+    0,
+  );
+  const perPerson =
+    selectedMembers.length > 0 ? totalAmount / selectedMembers.length : 0;
+
+  const memberSplits = selectedMembers.map(
+    ({ userId, username, avatarKey }) => {
+      const paid = selectedItems
+        .filter(({ createdBy }) => createdBy === userId)
+        .reduce((sum, { amount }) => sum + amount, 0);
+      const net = Math.round(paid - perPerson);
+      return {
+        userId,
+        username,
+        avatarKey,
+        status: net >= 0 ? ('receivable' as const) : ('payable' as const),
+        amount: Math.abs(net),
+      };
+    },
+  );
+
+  return { selectedItems, memberSplits };
+}
+
+export default useSplitPreview;

--- a/src/features/money/hooks/useSubmitSplit.ts
+++ b/src/features/money/hooks/useSubmitSplit.ts
@@ -1,0 +1,63 @@
+import { useState } from 'react';
+
+import { useQueryClient } from '@tanstack/react-query';
+import axios from 'axios';
+
+import { splitMoneyItems } from '@/api/endpoints/money';
+import { CURRENT_GROUP_ID_KEY } from '@/constants/auth';
+import moneyKeys from '@/features/money/queryKeys';
+
+type SubmitSplitResult =
+  | { success: true }
+  | { success: false; message: string };
+
+const getCurrentCareGroupId = () =>
+  window.localStorage.getItem(CURRENT_GROUP_ID_KEY);
+
+function getErrorMessage(error: unknown): string {
+  if (axios.isAxiosError(error)) {
+    const message = error.response?.data?.message;
+    if (typeof message === 'string' && message.trim().length > 0) {
+      return message;
+    }
+  }
+  return '發生預期外的問題，請稍後再嘗試';
+}
+
+function useSubmitSplit() {
+  const [isLoading, setIsLoading] = useState(false);
+  const queryClient = useQueryClient();
+
+  const handleSubmitSplit = async (
+    expenseIds: string[],
+    targetUserIds: string[],
+  ): Promise<SubmitSplitResult> => {
+    const careGroupId = getCurrentCareGroupId();
+
+    if (!careGroupId) {
+      return { success: false, message: '尚未選擇照護群組' };
+    }
+
+    setIsLoading(true);
+
+    try {
+      await splitMoneyItems(careGroupId, {
+        splitMode: 'custom',
+        expenseIds,
+        targetUserIds,
+      });
+      await queryClient.invalidateQueries({
+        queryKey: moneyKeys.group(careGroupId),
+      });
+      return { success: true };
+    } catch (error) {
+      return { success: false, message: getErrorMessage(error) };
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return { isLoading, handleSubmitSplit };
+}
+
+export default useSubmitSplit;

--- a/src/features/money/hooks/useUpdateMoneyItem.ts
+++ b/src/features/money/hooks/useUpdateMoneyItem.ts
@@ -32,7 +32,7 @@ function formatForPayload(
     amount: Number(draft.amount) || 0,
     category: draft.category ?? 'other',
     notes: draft.notes,
-    expenseDate: format(parsedDate, "yyyy-MM-dd'T'HH:mm:ss"),
+    expenseDate: format(parsedDate, "yyyy-MM-dd'T'HH:mm"),
     splitStatus: draft.needsSplit ? 'pending' : 'none',
     updatedAt: currentUpdatedAt,
   };

--- a/src/features/money/hooks/useUpdateMoneyItem.ts
+++ b/src/features/money/hooks/useUpdateMoneyItem.ts
@@ -2,7 +2,7 @@ import { useState } from 'react';
 
 import { useQueryClient } from '@tanstack/react-query';
 import axios from 'axios';
-import { format, parse } from 'date-fns';
+import { formatISO, parse } from 'date-fns';
 
 import { updateMoneyItem } from '@/api/endpoints/money';
 import { CURRENT_GROUP_ID_KEY } from '@/constants/auth';
@@ -32,7 +32,7 @@ function formatForPayload(
     amount: Number(draft.amount) || 0,
     category: draft.category ?? 'other',
     notes: draft.notes,
-    expenseDate: format(parsedDate, "yyyy-MM-dd'T'HH:mm"),
+    expenseDate: formatISO(parsedDate),
     splitStatus: draft.needsSplit ? 'pending' : 'none',
     updatedAt: currentUpdatedAt,
   };

--- a/src/features/money/queryKeys.ts
+++ b/src/features/money/queryKeys.ts
@@ -5,6 +5,8 @@ const moneyKeys = {
     [...moneyKeys.group(careGroupId), month] as const,
   detail: (careGroupId: string, expenseId: string) =>
     [...moneyKeys.group(careGroupId), expenseId] as const,
+  memberTotals: (careGroupId: string, month: string) =>
+    [...moneyKeys.group(careGroupId), 'member-totals', month] as const,
 };
 
 export default moneyKeys;

--- a/src/features/money/types.ts
+++ b/src/features/money/types.ts
@@ -42,6 +42,27 @@ type CategoryTotals = Record<MoneyCategoryValue, number>;
 
 type MoneyTab = 'daily' | 'monthly';
 
+type SplitItem = {
+  id: string;
+  title: string;
+  amount: number;
+};
+
+type SplitPendingItem = SplitItem & {
+  createdBy: string;
+};
+
+type SplitMember = {
+  userId: string;
+  username: string;
+  avatarKey: string;
+};
+
+type MemberSplit = SplitMember & {
+  status: 'receivable' | 'payable';
+  amount: number;
+};
+
 export type {
   SplitStatus,
   MoneyCategoryValue,
@@ -51,4 +72,8 @@ export type {
   CategoryWithAmount,
   CategoryTotals,
   MoneyTab,
+  SplitItem,
+  SplitPendingItem,
+  SplitMember,
+  MemberSplit,
 };

--- a/src/pages/Homepage/components/HomepageLayout.tsx
+++ b/src/pages/Homepage/components/HomepageLayout.tsx
@@ -79,6 +79,7 @@ function HomepageLayout({ className }: HomepageLayoutProps) {
     variant: 'success',
     title: '',
   });
+  const [moneyCreateSuccessOpen, setMoneyCreateSuccessOpen] = useState(false);
   const [isGroupEntryDrawerOpen, setIsGroupEntryDrawerOpen] = useState(false);
   const [groupEntryMode, setGroupEntryMode] = useState<'create' | 'edit'>(
     'create',
@@ -481,6 +482,10 @@ function HomepageLayout({ className }: HomepageLayoutProps) {
             <CreateMoneyDataCard
               initialDate={selectedDate}
               onClose={() => setShowCreateMoneyCard(false)}
+              onSuccess={() => {
+                setShowCreateMoneyCard(false);
+                setMoneyCreateSuccessOpen(true);
+              }}
               onVoiceInput={() => {
                 setShowCreateMoneyCard(false);
                 setShowQuickRecordingDrawer(true);
@@ -588,6 +593,15 @@ function HomepageLayout({ className }: HomepageLayoutProps) {
         onClose={() =>
           setHealthSubmitModal((prev) => ({ ...prev, open: false }))
         }
+      />
+
+      <Modal
+        open={moneyCreateSuccessOpen}
+        variant="success"
+        title="帳目建立完成！"
+        statusLayout="icon-first"
+        autoCloseMs={1500}
+        onClose={() => setMoneyCreateSuccessOpen(false)}
       />
     </>
   );

--- a/src/pages/MoneyPage.tsx
+++ b/src/pages/MoneyPage.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 
 import FixedBottomButton from '@/components/common/FixedBottomButton';
 import Loading from '@/components/common/Loading';
+import Modal from '@/components/common/Modal';
 import { PageNavigationBar } from '@/components/common/NavigationBar';
 import SideMenu from '@/components/common/SideMenu';
 import {
@@ -20,10 +21,11 @@ import RecordingDrawer from '@/features/voice/components/RecordingDrawer';
 
 function MoneyPage() {
   const { activeTab } = useActivedMoneyTab();
-  const { monthlyExpenses, cardListItems, isLoading } = useActiveExpenses();
+  const { cardListItems, isLoading } = useActiveExpenses();
   const [isSideMenuOpen, setIsSideMenuOpen] = useState(false);
   const [showCreateCard, setShowCreateCard] = useState(false);
   const [showRecordingDrawer, setShowRecordingDrawer] = useState(false);
+  const [createSuccessOpen, setCreateSuccessOpen] = useState(false);
 
   return (
     <main className="mx-auto flex min-h-screen w-full max-w-200 flex-col bg-neutral-200 pb-20 text-neutral-900">
@@ -41,9 +43,7 @@ function MoneyPage() {
         </div>
       ) : (
         <>
-          {activeTab === 'monthly' && (
-            <MemberExpenseSummary expenses={monthlyExpenses} />
-          )}
+          {activeTab === 'monthly' && <MemberExpenseSummary />}
           <CardsList items={cardListItems} />
         </>
       )}
@@ -60,6 +60,10 @@ function MoneyPage() {
           <AlertDialogPopup className="w-[calc(100vw-32px)] max-w-140 border-0 bg-transparent p-0 shadow-none">
             <CreateDataCard
               onClose={() => setShowCreateCard(false)}
+              onSuccess={() => {
+                setShowCreateCard(false);
+                setCreateSuccessOpen(true);
+              }}
               onVoiceInput={() => {
                 setShowCreateCard(false);
                 setShowRecordingDrawer(true);
@@ -76,6 +80,15 @@ function MoneyPage() {
       />
 
       <SideMenu open={isSideMenuOpen} onOpenChange={setIsSideMenuOpen} />
+
+      <Modal
+        open={createSuccessOpen}
+        variant="success"
+        title="帳目建立完成！"
+        statusLayout="icon-first"
+        autoCloseMs={1500}
+        onClose={() => setCreateSuccessOpen(false)}
+      />
     </main>
   );
 }

--- a/src/types/money.ts
+++ b/src/types/money.ts
@@ -50,12 +50,67 @@ type SplitMode = 'daily' | 'monthly' | 'custom';
 type SplitMoneyPayload = {
   splitMode: SplitMode;
   expenseIds: string[];
+  targetDate?: string;
   targetUserIds: string[];
 };
 
 type SplitResponse = {
   success: boolean;
   message: string;
+  data: null;
+};
+
+type SplitPreviewItem = {
+  id: string;
+  title: string;
+  amount: number;
+};
+
+type SplitDetail = {
+  userId: string;
+  name: string;
+  avatarUrl: string;
+  isPayer: boolean;
+  receivableAmount: number;
+  payableAmount: number;
+};
+
+type SplitPreviewData = {
+  totalAmount: number;
+  selectedExpenses: SplitPreviewItem[];
+  splitDetails: SplitDetail[];
+};
+
+type SplitPreviewResponse = {
+  success: boolean;
+  message: string;
+  data: SplitPreviewData;
+};
+
+type MemberTotalItem = {
+  userId: string;
+  name: string;
+  avatarUrl: string | null;
+  totalAmount: number;
+  expenseCount: number;
+};
+
+type MemberTotalsData = {
+  totalAmount: number;
+  memberCount: number;
+  members: MemberTotalItem[];
+};
+
+type MemberTotalsResponse = {
+  success: boolean;
+  message: string;
+  data: MemberTotalsData;
+};
+
+type MemberTotalsParams = {
+  scope?: 'daily' | 'monthly' | 'all';
+  targetDate?: string;
+  pendingOnly?: boolean;
 };
 
 export type {
@@ -64,6 +119,15 @@ export type {
   GetMoneyItemsResponse,
   MoneyItemResponse,
   UpdateMoneyItemPayLoad,
+  SplitMode,
   SplitMoneyPayload,
   SplitResponse,
+  SplitPreviewItem,
+  SplitDetail,
+  SplitPreviewData,
+  SplitPreviewResponse,
+  MemberTotalItem,
+  MemberTotalsData,
+  MemberTotalsResponse,
+  MemberTotalsParams,
 };

--- a/src/types/money.ts
+++ b/src/types/money.ts
@@ -45,10 +45,25 @@ type GetMoneyItemsParams = {
   EndDate?: string;
 };
 
+type SplitMode = 'daily' | 'monthly' | 'custom';
+
+type SplitMoneyPayload = {
+  splitMode: SplitMode;
+  expenseIds: string[];
+  targetUserIds: string[];
+};
+
+type SplitResponse = {
+  success: boolean;
+  message: string;
+};
+
 export type {
   CreateMoneyItemPayLoad,
   GetMoneyItemsParams,
   GetMoneyItemsResponse,
   MoneyItemResponse,
   UpdateMoneyItemPayLoad,
+  SplitMoneyPayload,
+  SplitResponse,
 };


### PR DESCRIPTION
- Implemented full money split flow including item selection, result preview, and submission.
- Integrated real API endpoints for split operations and member spending statistics.
- Added `useFetchSplitPreview`, `useSubmitSplit`, and `useMemberTotals` custom hooks.
- Created reusable split UI components: `SplitDialog`, `SplitItemCard`, `SplitParticipant`, and `SplitResultPreview`.
- Refactored `MemberExpenseSummary` to fetch real-time member totals from the backend.
- Standardized success feedback across money features with auto-closing Modals.
- Unified date handling by using `parseISO` and `formatISO` for consistent API communication.
- Increased Calendar font sizes to 16px to improve readability.
- Optimized "Split" button logic to trigger only when pending items exist.
- Moved API-related split types to the global `types/money.ts` for better architectural separation.
