### PR TITLE
Feature/voice-dataform-submit-api

### DIFF
--- a/src/api/endpoints/money.ts
+++ b/src/api/endpoints/money.ts
@@ -38,5 +38,4 @@ const updateMoneyItem = (
 const deleteMoneyItem = (careGroupId: string, expenseId: string) =>
   apiClient.delete(buildMoneyItemPath(careGroupId, expenseId));
 
-
 export { getMoneyItems, createMoneyItem, updateMoneyItem, deleteMoneyItem };

--- a/src/components/common/NavigationBar.tsx
+++ b/src/components/common/NavigationBar.tsx
@@ -282,9 +282,7 @@ function HomepageNavigationBar({
 }: HomepageNavigationBarProps) {
   return (
     <div className={cn('border-b-2 border-neutral-900', className)}>
-      <div
-        className="grid grid-cols-[1fr_auto_1fr] items-center pt-2 pb-5"
-      >
+      <div className="grid grid-cols-[1fr_auto_1fr] items-center pt-2 pb-5">
         <NavigationDateBadge
           selectedDate={selectedDate}
           onClick={onDateClick}
@@ -318,9 +316,7 @@ function PageNavigationBar({
 }: PageNavigationBarProps) {
   return (
     <div className={cn('border-b-2 border-neutral-900', className)}>
-      <div
-        className="grid grid-cols-[1fr_auto_1fr] items-center pt-2 pb-5"
-      >
+      <div className="grid grid-cols-[1fr_auto_1fr] items-center pt-2 pb-5">
         {showTitle ? (
           <NavigationTitle
             as="span"

--- a/src/features/groups/components/QRCodeScannerPanel.tsx
+++ b/src/features/groups/components/QRCodeScannerPanel.tsx
@@ -134,7 +134,7 @@ function QRCodeScannerPanel({ onBack, onDetected }: QRCodeScannerPanelProps) {
       <div className="relative mx-auto w-full max-w-50 overflow-hidden rounded-xl border-2 border-neutral-900 bg-neutral-800">
         <div
           id={scannerElementId}
-          className="aspect-square w-full [&>div]:!h-full [&>div]:!w-full [&_canvas]:!h-full [&_canvas]:!w-full [&_video]:!h-full [&_video]:!w-full [&_video]:object-cover"
+          className="aspect-square w-full [&_canvas]:!h-full [&_canvas]:!w-full [&_video]:!h-full [&_video]:!w-full [&_video]:object-cover [&>div]:!h-full [&>div]:!w-full"
         />
         <div className="pointer-events-none absolute inset-2 rounded-xl border-2 border-dashed border-neutral-50" />
       </div>

--- a/src/features/health/hooks/useCreateHealthData.ts
+++ b/src/features/health/hooks/useCreateHealthData.ts
@@ -115,7 +115,10 @@ function useCreateHealthData({
   }
 
   const onSubmit = async (values: HealthDataFormValues) => {
-    const promises = buildHealthSubmissions(values, toISODate(recordDate, recordTime));
+    const promises = buildHealthSubmissions(
+      values,
+      toISODate(recordDate, recordTime),
+    );
 
     if (promises.length === 0) return;
 

--- a/src/features/health/hooks/useCreateHealthData.ts
+++ b/src/features/health/hooks/useCreateHealthData.ts
@@ -68,8 +68,10 @@ function useCreateHealthData({
   const hasAnyValue =
     Object.values(watchedValues).some((v) => v !== '') && bloodPressureValid;
 
-  const onSubmit = async (values: HealthDataFormValues) => {
-    const isoDate = toISODate(recordDate, recordTime);
+  function buildHealthSubmissions(
+    values: HealthDataFormValues,
+    isoDate: string,
+  ): Promise<unknown>[] {
     const promises: Promise<unknown>[] = [];
 
     if (values.spO2) {
@@ -109,6 +111,12 @@ function useCreateHealthData({
       );
     }
 
+    return promises;
+  }
+
+  const onSubmit = async (values: HealthDataFormValues) => {
+    const promises = buildHealthSubmissions(values, toISODate(recordDate, recordTime));
+
     if (promises.length === 0) return;
 
     setIsSubmitting(true);
@@ -123,6 +131,26 @@ function useCreateHealthData({
     } finally {
       setIsSubmitting(false);
     }
+  };
+
+  const submitFromDraft = async (draft: HealthDraft) => {
+    const promises = buildHealthSubmissions(
+      {
+        spO2: draft.bloodOxygen,
+        systolic: draft.systolic,
+        diastolic: draft.diastolic,
+        temperature: draft.temperature,
+        weight: draft.weight,
+        glucoseLevel: draft.bloodSugar,
+      },
+      toISODate(draft.dateValue, draft.timeValue),
+    );
+
+    if (promises.length === 0) return { success: true };
+
+    const results = await Promise.allSettled(promises);
+
+    return { success: results.every((r) => r.status === 'fulfilled') };
   };
 
   const applyVoiceDraft = (draft: HealthDraft, transcript: string) => {
@@ -160,6 +188,7 @@ function useCreateHealthData({
     setRecordDate,
     setRecordTime,
     applyVoiceDraft,
+    submitFromDraft,
   };
 }
 

--- a/src/features/money/components/EntryCard.tsx
+++ b/src/features/money/components/EntryCard.tsx
@@ -108,7 +108,7 @@ function EntryCard({ item }: { item: ExpenseItem }) {
         <AlertDialogPortal>
           <AlertDialogBackdrop />
           <AlertDialogPopup className="border-0 bg-transparent">
-              <ItemDetailsCard
+            <ItemDetailsCard
               item={item}
               onDeleteClick={handleDeleteClick}
               onEditClick={handleEditClick}

--- a/src/features/money/hooks/useCreateMoneyItem.ts
+++ b/src/features/money/hooks/useCreateMoneyItem.ts
@@ -19,8 +19,8 @@ const getCurrentCareGroupId = () =>
 
 function formatForPayload(draft: MoneyDraft): CreateMoneyItemPayLoad {
   const parsedDate = parse(
-    `${draft.dateValue} ${draft.timeValue}`,
-    'yyyy/MM/dd HH:mm',
+    `${draft.dateValue.replace(/\//g, '-')} ${draft.timeValue}`,
+    'yyyy-MM-dd HH:mm',
     new Date(),
   );
 

--- a/src/features/voice/components/DataFormCardCarousel.tsx
+++ b/src/features/voice/components/DataFormCardCarousel.tsx
@@ -13,6 +13,7 @@ import Modal from '@/components/common/Modal';
 import { RoundedButtonSecondary } from '@/components/common/RoundedButtons';
 import type { HealthDraft } from '@/features/health/types';
 import type { MoneyDraft } from '@/features/money/types';
+import useVoiceDraftSubmit from '@/features/voice/hooks/useVoiceDraftSubmit';
 import {
   createEmptyDiaryDraft,
   hasDiaryDraftContent,
@@ -28,7 +29,6 @@ import {
   mergeMoneyDraft,
 } from '@/features/voice/services/moneyParser';
 import { useVoiceInput } from '@/features/voice/VoiceInputContext';
-import useVoiceDraftSubmit from '@/features/voice/hooks/useVoiceDraftSubmit';
 import type { DiaryDraft } from '@/pages/CareLog/types';
 
 import DiaryDataFormCard from './DiaryDataFormCard';
@@ -255,13 +255,13 @@ function DataFormCardCarousel() {
         <RoundedButtonSecondary
           className="h-12 max-w-[97px] border-neutral-50 bg-neutral-800 text-neutral-50 transition-colors duration-300 active:bg-neutral-50 active:text-neutral-800 disabled:opacity-50"
           disabled={isSubmitting}
-          onClick={() => {
+          onClick={async () => {
             if (!isLastSlide) {
               swiper?.slideNext();
               return;
             }
 
-            void handleSaveAll();
+            await handleSaveAll();
           }}
         >
           {isLastSlide ? '儲存全部' : '確認'}

--- a/src/features/voice/components/DataFormCardCarousel.tsx
+++ b/src/features/voice/components/DataFormCardCarousel.tsx
@@ -28,6 +28,7 @@ import {
   mergeMoneyDraft,
 } from '@/features/voice/services/moneyParser';
 import { useVoiceInput } from '@/features/voice/VoiceInputContext';
+import useVoiceDraftSubmit from '@/features/voice/hooks/useVoiceDraftSubmit';
 import type { DiaryDraft } from '@/pages/CareLog/types';
 
 import DiaryDataFormCard from './DiaryDataFormCard';
@@ -194,6 +195,16 @@ function DataFormCardCarousel() {
 
   const isLastSlide = activeIndex === visibleSlides.length - 1;
 
+  const { isSubmitting, handleSaveAll } = useVoiceDraftSubmit({
+    healthDraft: activeHealthDraft,
+    diaryDrafts: renderedDiaryDrafts,
+    moneyDraft: activeMoneyDraft,
+    groupMembers,
+    shouldSubmitHealth: shouldShowHealthForm,
+    shouldSubmitMoney: shouldShowMoneyForm,
+    onSuccess: () => setShowSuccessModal(true),
+  });
+
   const handleCloseResultFlow = () => {
     setShowSuccessModal(false);
     clearVoiceInput();
@@ -242,13 +253,15 @@ function DataFormCardCarousel() {
 
       <div className="mt-6 flex flex-col items-center gap-3 px-4">
         <RoundedButtonSecondary
-          className="h-12 max-w-[97px] border-neutral-50 bg-neutral-800 text-neutral-50 transition-colors duration-300 active:bg-neutral-50 active:text-neutral-800"
+          className="h-12 max-w-[97px] border-neutral-50 bg-neutral-800 text-neutral-50 transition-colors duration-300 active:bg-neutral-50 active:text-neutral-800 disabled:opacity-50"
+          disabled={isSubmitting}
           onClick={() => {
-            if (isLastSlide) {
-              setShowSuccessModal(true);
-            } else {
+            if (!isLastSlide) {
               swiper?.slideNext();
+              return;
             }
+
+            void handleSaveAll();
           }}
         >
           {isLastSlide ? '儲存全部' : '確認'}

--- a/src/features/voice/components/RecordingDrawer.tsx
+++ b/src/features/voice/components/RecordingDrawer.tsx
@@ -115,8 +115,13 @@ function RecordingDrawer({
   const isFinishDisabled = isProcessing || displayText === '';
 
   useEffect(() => {
-    if (!open) {
+    if (open) {
+      resetTranscript();
+      startListening();
+    } else if (open === false) {
       setIsProcessing(false);
+      stopListening();
+      resetTranscript();
     }
   }, [open]);
 
@@ -186,7 +191,7 @@ function RecordingDrawer({
           <AudioLines
             className={
               isListening && !isProcessing
-                ? 'text-primary-default size-10 scale-130 animate-pulse transition-all duration-200 ease-out'
+                ? 'text-primary-dark size-10 scale-130 animate-pulse transition-all duration-100 ease-out'
                 : 'size-10 text-neutral-500'
             }
           />

--- a/src/features/voice/components/RecordingDrawer.tsx
+++ b/src/features/voice/components/RecordingDrawer.tsx
@@ -123,7 +123,7 @@ function RecordingDrawer({
       stopListening();
       resetTranscript();
     }
-  }, [open]);
+  }, [open, resetTranscript, startListening, stopListening]);
 
   const resetButtonClassName = isProcessing
     ? 'font-label-sm flex items-center justify-center gap-2 text-neutral-500 transition-opacity'

--- a/src/features/voice/hooks/useSpeechRecognition.ts
+++ b/src/features/voice/hooks/useSpeechRecognition.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 type SpeechRecognitionResult = {
   isSupported: boolean;
@@ -50,6 +50,7 @@ function useSpeechRecognition(): SpeechRecognitionResult {
   const [transcript, setTranscript] = useState('');
   const [interimTranscript, setInterimTranscript] = useState('');
   const [error, setError] = useState<string | null>(null);
+  const isListeningRef = useRef(false);
 
   useEffect(() => {
     const SpeechRecognition =
@@ -66,16 +67,19 @@ function useSpeechRecognition(): SpeechRecognitionResult {
       recognition.lang = 'zh-TW';
 
       recognition.onstart = () => {
+        isListeningRef.current = true;
         setIsListening(true);
         setError(null);
       };
 
       recognition.onend = () => {
+        isListeningRef.current = false;
         setIsListening(false);
         setInterimTranscript('');
       };
 
       recognition.onerror = (event) => {
+        isListeningRef.current = false;
         setError(event.error);
         setIsListening(false);
       };
@@ -115,17 +119,17 @@ function useSpeechRecognition(): SpeechRecognitionResult {
     };
   }, []);
 
-  const startListening = () => {
-    if (!recognitionRef.current || isListening) return;
+  const startListening = useCallback(() => {
+    if (!recognitionRef.current || isListeningRef.current) return;
 
     try {
       recognitionRef.current.start();
     } catch {
       setError('start-failed');
     }
-  };
+  }, []);
 
-  const stopListening = () => {
+  const stopListening = useCallback(() => {
     if (!recognitionRef.current) return;
 
     try {
@@ -133,13 +137,13 @@ function useSpeechRecognition(): SpeechRecognitionResult {
     } catch {
       setError('stop-failed');
     }
-  };
+  }, []);
 
-  const resetTranscript = () => {
+  const resetTranscript = useCallback(() => {
     setTranscript('');
     setInterimTranscript('');
     setError(null);
-  };
+  }, []);
 
   return {
     isSupported,

--- a/src/features/voice/hooks/useVoiceDraftSubmit.ts
+++ b/src/features/voice/hooks/useVoiceDraftSubmit.ts
@@ -1,0 +1,80 @@
+import { useState } from 'react';
+
+import { toast } from 'sonner';
+
+import useCreateHealthData from '@/features/health/hooks/useCreateHealthData';
+import type { HealthDraft } from '@/features/health/types';
+import useCreateMoneyItem from '@/features/money/hooks/useCreateMoneyItem';
+import type { MoneyDraft } from '@/features/money/types';
+import useCreateCareLogEntry from '@/pages/CareLog/hooks/useCreateCareLogEntry';
+import type { DiaryDraft } from '@/pages/CareLog/types';
+import { diaryDraftToCareLogEntry } from '@/pages/CareLog/utils/careLogVoice';
+import type { GroupMember } from '@/types/group';
+
+type UseVoiceDraftSubmitOptions = {
+  healthDraft: HealthDraft;
+  diaryDrafts: DiaryDraft[];
+  moneyDraft: MoneyDraft;
+  groupMembers: GroupMember[];
+  shouldSubmitHealth: boolean;
+  shouldSubmitMoney: boolean;
+  onSuccess: () => void;
+};
+
+function isFailedResult(result: PromiseSettledResult<unknown>): boolean {
+  if (result.status === 'rejected') return true;
+  const val = result.value;
+  if (val === null) return true;
+  if (val !== null && typeof val === 'object' && 'success' in val) {
+    return !(val as { success: boolean }).success;
+  }
+  return false;
+}
+
+function useVoiceDraftSubmit({
+  healthDraft,
+  diaryDrafts,
+  moneyDraft,
+  groupMembers,
+  shouldSubmitHealth,
+  shouldSubmitMoney,
+  onSuccess,
+}: UseVoiceDraftSubmitOptions) {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const { submitFromDraft: submitHealthDraft } = useCreateHealthData();
+  const { handleCreateMoneyItem } = useCreateMoneyItem();
+  const { handleCreateCareLogEntry } = useCreateCareLogEntry();
+
+  const handleSaveAll = async () => {
+    setIsSubmitting(true);
+
+    try {
+      const submissions: Promise<unknown>[] = [
+        ...(shouldSubmitHealth ? [submitHealthDraft(healthDraft)] : []),
+        ...diaryDrafts.map((draft) =>
+          handleCreateCareLogEntry(
+            diaryDraftToCareLogEntry(draft, groupMembers),
+          ),
+        ),
+        ...(shouldSubmitMoney ? [handleCreateMoneyItem(moneyDraft)] : []),
+      ];
+
+      const results = await Promise.allSettled(submissions);
+
+      if (results.some(isFailedResult)) {
+        toast.error('部分資料儲存失敗，請檢查後再試');
+      } else {
+        onSuccess();
+      }
+    } catch (error) {
+      console.error('[useVoiceDraftSubmit] 儲存失敗:', error);
+      toast.error('儲存時發生錯誤，請稍後再試');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return { isSubmitting, handleSaveAll };
+}
+
+export default useVoiceDraftSubmit;

--- a/src/features/voice/hooks/useVoiceDraftSubmit.ts
+++ b/src/features/voice/hooks/useVoiceDraftSubmit.ts
@@ -66,8 +66,7 @@ function useVoiceDraftSubmit({
       } else {
         onSuccess();
       }
-    } catch (error) {
-      console.error('[useVoiceDraftSubmit] 儲存失敗:', error);
+    } catch {
       toast.error('儲存時發生錯誤，請稍後再試');
     } finally {
       setIsSubmitting(false);

--- a/src/pages/CareLog/utils/careLogVoice.ts
+++ b/src/pages/CareLog/utils/careLogVoice.ts
@@ -2,11 +2,13 @@ import type { Dispatch, SetStateAction } from 'react';
 
 import { toast } from 'sonner';
 
+import getAvatarSrcByKey from '@/assets/images/avatars';
 import type { RepeatPatternValue } from '@/components/common/ListFormRows';
 import {
   hasDiaryDraftContent,
   parseDiaryTranscript,
 } from '@/features/voice/services/diaryParser';
+import type { CareLogEntry, DiaryDraft } from '@/pages/CareLog/types';
 import type { GroupMember } from '@/types/group';
 
 type CareLogVoiceFieldSetters = {
@@ -80,5 +82,35 @@ async function handleCareLogVoiceFinish({
   return { shouldClose: true };
 }
 
-export { handleCareLogVoiceFinish };
+function diaryDraftToCareLogEntry(
+  draft: DiaryDraft,
+  groupMembers: GroupMember[],
+): CareLogEntry {
+  const startsAt = new Date(
+    `${draft.dateValue.replace(/\//g, '-')}T${draft.timeValue}:00`,
+  ).toISOString();
+
+  const participants = draft.participantIds.map((id) => {
+    const member = groupMembers.find((m) => m.userId === id);
+
+    return {
+      id,
+      name: member?.username ?? '成員',
+      src: member ? getAvatarSrcByKey(member.avatarKey) : '',
+    };
+  });
+
+  return {
+    id: draft.id,
+    title: draft.title,
+    description: draft.note,
+    startsAt,
+    repeatPattern: draft.repeatPattern,
+    participants,
+    status: 'pending',
+    isImportant: draft.isImportant,
+  };
+}
+
+export { diaryDraftToCareLogEntry, handleCareLogVoiceFinish };
 export type { CareLogVoiceFieldSetters };


### PR DESCRIPTION
- Connect homepage voice result cards to create APIs for health, care log, and money entries
- Add a shared submit flow to save parsed voice drafts in a single action
- Convert parsed diary voice drafts into care log payloads before submission
- Normalize money draft date parsing so voice-created entries can be submitted correctly
- Auto-start recording when the controlled recording drawer is reopened from the result flow
- Disable the final submit button during requests and show partial failure feedback when any save action fails
