### PR TITLE
Feature/notification-page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,7 +19,8 @@ function App() {
     pathname === '/health-report' ||
     pathname === '/money' ||
     pathname === '/group-entrance' ||
-    pathname === '/homepage';
+    pathname === '/homepage' ||
+    pathname === '/notifications';
 
   return (
     <VoiceInputProvider>

--- a/src/components/common/CircleIButton.tsx
+++ b/src/components/common/CircleIButton.tsx
@@ -28,7 +28,7 @@ const sizeClassMap = {
   md: 'h-10 w-10 [&&_svg]:size-6 [&&_svg]:stroke-[2]',
   modal: 'h-10 w-10 [&&_svg]:size-4 [&&_svg]:stroke-[3]',
   lg: 'h-12 w-12 [&&_svg]:size-8 [&&_svg]:stroke-[2.5]',
-  notification: 'h-12 w-12 [&&_svg]:size-6 [&&_svg]:stroke-[2.5]',
+  notification: 'h-12 w-12 [&&_svg]:size-6 [&&_svg]:stroke-[1.5]',
 };
 
 // 1. Primary ：黑邊框、深色底

--- a/src/components/common/CircleIButton.tsx
+++ b/src/components/common/CircleIButton.tsx
@@ -5,7 +5,7 @@ import cn from '@/lib/utils';
 
 type CircleButtonProps = Omit<React.ComponentProps<typeof Button>, 'size'> & {
   children: ReactNode;
-  size?: 'sm' | 'md' | 'modal' | 'lg';
+  size?: 'sm' | 'md' | 'modal' | 'lg' | 'notification';
 };
 
 type CheckBoxButtonProps = CircleButtonProps & {
@@ -28,6 +28,7 @@ const sizeClassMap = {
   md: 'h-10 w-10 [&&_svg]:size-6 [&&_svg]:stroke-[2]',
   modal: 'h-10 w-10 [&&_svg]:size-4 [&&_svg]:stroke-[3]',
   lg: 'h-12 w-12 [&&_svg]:size-8 [&&_svg]:stroke-[2.5]',
+  notification: 'h-12 w-12 [&&_svg]:size-6 [&&_svg]:stroke-[2.5]',
 };
 
 // 1. Primary ：黑邊框、深色底

--- a/src/features/calendar/useDiaryCardActions.ts
+++ b/src/features/calendar/useDiaryCardActions.ts
@@ -9,6 +9,7 @@ type UseDiaryCardActionsOptions = {
   onDeleteEntry: (entryId: string) => Promise<boolean> | boolean;
   isUpdatingEntry?: boolean;
   isDeletingEntry?: boolean;
+  initialDetailEntryId?: string;
 };
 
 export type UseDiaryCardActionsResult = {
@@ -37,8 +38,11 @@ function useDiaryCardActions({
   onDeleteEntry,
   isUpdatingEntry = false,
   isDeletingEntry = false,
+  initialDetailEntryId,
 }: UseDiaryCardActionsOptions): UseDiaryCardActionsResult {
-  const [detailEntryId, setDetailEntryId] = useState<string | null>(null);
+  const [detailEntryId, setDetailEntryId] = useState<string | null>(
+    initialDetailEntryId ?? null,
+  );
   const [selectedActionEntryId, setSelectedActionEntryId] = useState<
     string | null
   >(null);

--- a/src/features/groups/components/GroupManageContent.tsx
+++ b/src/features/groups/components/GroupManageContent.tsx
@@ -8,6 +8,7 @@ type GroupManageContentProps = {
   isSelected: boolean;
   onSelect: () => void;
   onManage: () => void;
+  showManageButton?: boolean;
 };
 
 function GroupManageContent({
@@ -15,6 +16,7 @@ function GroupManageContent({
   isSelected,
   onSelect,
   onManage,
+  showManageButton = true,
 }: GroupManageContentProps) {
   return (
     <div
@@ -53,17 +55,19 @@ function GroupManageContent({
             <Check />
           </span>
         ) : null}
-        <button
-          type="button"
-          aria-label={`管理${group.name}`}
-          onClick={(event) => {
-            event.stopPropagation();
-            onManage();
-          }}
-          className="inline-flex size-8 items-center justify-center text-neutral-900"
-        >
-          <Ellipsis />
-        </button>
+        {showManageButton ? (
+          <button
+            type="button"
+            aria-label={`管理${group.name}`}
+            onClick={(event) => {
+              event.stopPropagation();
+              onManage();
+            }}
+            className="inline-flex size-8 items-center justify-center text-neutral-900"
+          >
+            <Ellipsis />
+          </button>
+        ) : null}
       </div>
     </div>
   );

--- a/src/features/groups/components/GroupManagementDrawer.tsx
+++ b/src/features/groups/components/GroupManagementDrawer.tsx
@@ -12,6 +12,7 @@ type GroupManagementDrawerProps = {
   onManageGroup: (groupId: string) => void;
   onJoinGroup: () => void;
   onCreateGroup: () => void;
+  showManageButton?: boolean;
 };
 
 function GroupManagementDrawer({
@@ -21,6 +22,7 @@ function GroupManagementDrawer({
   onManageGroup,
   onJoinGroup,
   onCreateGroup,
+  showManageButton = true,
 }: GroupManagementDrawerProps) {
   return (
     <div className="flex min-h-48 flex-col text-neutral-900">
@@ -32,30 +34,35 @@ function GroupManagementDrawer({
             isSelected={group.id === selectedGroupId}
             onSelect={() => onSelectGroup(group.id)}
             onManage={() => onManageGroup(group.id)}
+            showManageButton={showManageButton}
           />
         ))}
 
-        <button
-          type="button"
-          className="flex w-full items-center justify-between gap-4 bg-neutral-300 px-4 py-3 text-left"
-          onClick={onJoinGroup}
-        >
-          <div className="flex items-center gap-2">
-            <span className="inline-flex size-8 items-center justify-center rounded-full bg-neutral-400 text-neutral-900">
-              <Plus />
-            </span>
-            <p className="font-label-md">加入其他群組</p>
-          </div>
-        </button>
+        {showManageButton ? (
+          <button
+            type="button"
+            className="flex w-full items-center justify-between gap-4 bg-neutral-300 px-4 py-3 text-left"
+            onClick={onJoinGroup}
+          >
+            <div className="flex items-center gap-2">
+              <span className="inline-flex size-8 items-center justify-center rounded-full bg-neutral-400 text-neutral-900">
+                <Plus />
+              </span>
+              <p className="font-label-md">加入其他群組</p>
+            </div>
+          </button>
+        ) : null}
       </div>
 
-      <RoundedButtonPrimary
-        className="mt-5 border-2 border-neutral-900 bg-neutral-50 text-neutral-900"
-        type="button"
-        onClick={onCreateGroup}
-      >
-        建立新群組
-      </RoundedButtonPrimary>
+      {showManageButton ? (
+        <RoundedButtonPrimary
+          className="mt-5 border-2 border-neutral-900 bg-neutral-50 text-neutral-900"
+          type="button"
+          onClick={onCreateGroup}
+        >
+          建立新群組
+        </RoundedButtonPrimary>
+      ) : null}
     </div>
   );
 }

--- a/src/features/money/components/CardsList.tsx
+++ b/src/features/money/components/CardsList.tsx
@@ -22,6 +22,7 @@ const SPLIT_FILTER_OPTIONS: FilterOption<SplitFilter>[] = [
 
 type CardsListProps = {
   items: ExpenseItem[];
+  initialOpenExpenseId?: string;
 };
 
 const filterItems = (items: ExpenseItem[], filter: SplitFilter) => {
@@ -50,7 +51,7 @@ const groupByDate = (items: ExpenseItem[]): DateGroup[] => {
   }, []);
 };
 
-function CardsList({ items }: CardsListProps) {
+function CardsList({ items, initialOpenExpenseId }: CardsListProps) {
   const [filter, setFilter] = useState<SplitFilter>('all');
   const { activeTab } = useActivedMoneyTab();
   const filteredItems = filterItems(items, filter);
@@ -88,7 +89,11 @@ function CardsList({ items }: CardsListProps) {
               </p>
             )}
             {group.items.map((item) => (
-              <EntryCard key={item.id} item={item} />
+              <EntryCard
+                key={item.id}
+                item={item}
+                initialOpen={item.id === initialOpenExpenseId}
+              />
             ))}
           </div>
         ))}

--- a/src/features/money/components/CreateDataCard.tsx
+++ b/src/features/money/components/CreateDataCard.tsx
@@ -18,7 +18,11 @@ type CreateDataCardProps = {
   initialDate?: Date;
 };
 
-function CreateDataCard({ onClose, onSuccess, initialDate }: CreateDataCardProps) {
+function CreateDataCard({
+  onClose,
+  onSuccess,
+  initialDate,
+}: CreateDataCardProps) {
   const [draft, setDraft] = useState<MoneyDraft>(() => {
     const base = createEmptyMoneyDraft();
     const now = initialDate ?? new Date();

--- a/src/features/money/components/EntryCard.tsx
+++ b/src/features/money/components/EntryCard.tsx
@@ -25,12 +25,18 @@ import useCurrentGroupId from '@/hooks/useCurrentGroupID';
 import ItemDetailsCard from './ItemDetailsCard';
 import UpdateDataCard from './UpdateDataCard';
 
-function EntryCard({ item }: { item: ExpenseItem }) {
+function EntryCard({
+  item,
+  initialOpen = false,
+}: {
+  item: ExpenseItem;
+  initialOpen?: boolean;
+}) {
   const { currentGroupId } = useCurrentGroupId();
   const { data: groupMembers = [] } = useGetGroupMembers(currentGroupId);
   const creator = groupMembers.find((m) => m.userId === item.createdBy);
   const [drawerOpen, setDrawerOpen] = useState(false);
-  const [dialogOpen, setDialogOpen] = useState(false);
+  const [dialogOpen, setDialogOpen] = useState(initialOpen);
   const [updateOpen, setUpdateOpen] = useState(false);
   const [updateSuccessOpen, setUpdateSuccessOpen] = useState(false);
   const [confirmOpen, setConfirmOpen] = useState(false);

--- a/src/pages/CareLog/CalendarPage.tsx
+++ b/src/pages/CareLog/CalendarPage.tsx
@@ -38,6 +38,16 @@ function getSelectedDateFromState(state: unknown) {
   return isValid(parsedDate) ? parsedDate : undefined;
 }
 
+function getEntryIdFromState(state: unknown) {
+  if (!state || typeof state !== 'object' || !('entryId' in state)) {
+    return undefined;
+  }
+
+  const { entryId } = state as { entryId?: unknown };
+
+  return typeof entryId === 'string' ? entryId : undefined;
+}
+
 function CalendarPage() {
   const location = useLocation();
   const { isLoading: isDeletingEntry, handleDeleteCareLogEntry } =
@@ -46,6 +56,7 @@ function CalendarPage() {
     useUpdateCareLogEntry();
   const { entries: fetchedEntries, refetchEntries } = useGetCareLogEntries();
   const initialSelectedDate = getSelectedDateFromState(location.state);
+  const initialDetailEntryId = getEntryIdFromState(location.state);
   const [isSideMenuOpen, setIsSideMenuOpen] = useState(false);
   const [selectedDate, setSelectedDate] = useState<Date | undefined>(
     initialSelectedDate ?? defaultSelectedDate,
@@ -112,6 +123,7 @@ function CalendarPage() {
           items={selectedEntries}
           selectedDate={selectedDate}
           onCreateEntry={openCreateEntry}
+          initialDetailEntryId={initialDetailEntryId}
           isUpdatingEntry={isUpdatingEntry}
           isDeletingEntry={isDeletingEntry}
           onToggleStatus={async (entryId, status) => {

--- a/src/pages/CareLog/components/CareLogDiarySection.tsx
+++ b/src/pages/CareLog/components/CareLogDiarySection.tsx
@@ -21,6 +21,7 @@ type CareLogDiarySectionProps = {
   onCreateEntry: (date?: Date) => void;
   isUpdatingEntry?: boolean;
   isDeletingEntry?: boolean;
+  initialDetailEntryId?: string;
 };
 
 const statusFilterOptions = [
@@ -39,6 +40,7 @@ function CareLogDiarySection({
   onCreateEntry,
   isUpdatingEntry = false,
   isDeletingEntry = false,
+  initialDetailEntryId,
 }: CareLogDiarySectionProps) {
   const [statusFilter, setStatusFilter] = useState<CareLogFilterValue>('all');
   const diaryCardActions = useDiaryCardActions({
@@ -47,6 +49,7 @@ function CareLogDiarySection({
     onDeleteEntry,
     isUpdatingEntry,
     isDeletingEntry,
+    initialDetailEntryId,
   });
   const now = new Date();
   const activeItems = items;

--- a/src/pages/Homepage/components/HomepageLayout.tsx
+++ b/src/pages/Homepage/components/HomepageLayout.tsx
@@ -370,6 +370,7 @@ function HomepageLayout({ className }: HomepageLayoutProps) {
       >
         <HomepageNavigationBar
           hasNotification
+          onNotificationClick={() => navigate('/notifications')}
           onMenuClick={() => setIsSideMenuOpen(true)}
           selectedDate={selectedDate}
           onDateClick={() => setIsDateDrawerOpen(true)}

--- a/src/pages/Homepage/components/HomepageLayout.tsx
+++ b/src/pages/Homepage/components/HomepageLayout.tsx
@@ -37,6 +37,7 @@ import cn from '@/lib/utils';
 import CreateCareLogDialog from '@/pages/CareLog/components/CreateCareLogDialog';
 import type { CareLogEntry } from '@/pages/CareLog/types';
 import createDraftCareLogEntry from '@/pages/CareLog/utils/createDraftCareLogEntry';
+import useNotificationBadge from '@/pages/Notification/hooks/useNotificationBadge';
 import type { UserInfo } from '@/types/auth';
 import type { GroupMember } from '@/types/group';
 
@@ -50,6 +51,7 @@ type HomepageLayoutProps = {
 
 function HomepageLayout({ className }: HomepageLayoutProps) {
   const queryClient = useQueryClient();
+  const { hasUnread } = useNotificationBadge();
   const { data: groups = [] } = useGetGroups();
   const { handleDeleteGroupMember } = useDeleteGroupMember();
   const { currentGroupId, setCurrentGroupId } = useCurrentGroupId();
@@ -369,7 +371,7 @@ function HomepageLayout({ className }: HomepageLayoutProps) {
         )}
       >
         <HomepageNavigationBar
-          hasNotification
+          hasNotification={hasUnread}
           onNotificationClick={() => navigate('/notifications')}
           onMenuClick={() => setIsSideMenuOpen(true)}
           selectedDate={selectedDate}

--- a/src/pages/MoneyPage.tsx
+++ b/src/pages/MoneyPage.tsx
@@ -1,4 +1,7 @@
-import { useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+
+import { isValid, parseISO } from 'date-fns';
+import { useLocation } from 'react-router';
 
 import FixedBottomButton from '@/components/common/FixedBottomButton';
 import Loading from '@/components/common/Loading';
@@ -17,11 +20,43 @@ import MemberExpenseSummary from '@/features/money/components/MemberExpenseSumma
 import MoneyTabsCard from '@/features/money/components/MoneyTabsCard';
 import useActivedMoneyTab from '@/features/money/hooks/useActivedMoneyTab';
 import useActiveExpenses from '@/features/money/hooks/useActiveExpenses';
+import useSelectedDate from '@/features/money/hooks/useSelectedDate';
 
 function MoneyPage() {
-  const { activeTab } = useActivedMoneyTab();
+  const location = useLocation();
+  const { activeTab, setActivedMoneyTab } = useActivedMoneyTab();
+  const { setSelectedDate } = useSelectedDate();
   const { cardListItems, isLoading } = useActiveExpenses();
   const [isSideMenuOpen, setIsSideMenuOpen] = useState(false);
+
+  const initialOpenExpenseId = useMemo(() => {
+    if (
+      !location.state ||
+      typeof location.state !== 'object' ||
+      !('expenseId' in location.state)
+    ) {
+      return undefined;
+    }
+    const { expenseId } = location.state as { expenseId?: unknown };
+    return typeof expenseId === 'string' ? expenseId : undefined;
+  }, [location.state]);
+
+  useEffect(() => {
+    if (
+      !location.state ||
+      typeof location.state !== 'object' ||
+      !('date' in location.state)
+    ) {
+      return;
+    }
+    const { date } = location.state as { date?: unknown };
+    if (typeof date !== 'string') return;
+    const parsed = parseISO(date.replace('Z', ''));
+    if (!isValid(parsed)) return;
+    setSelectedDate(parsed);
+    setActivedMoneyTab('daily');
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [location.state]);
   const [showCreateCard, setShowCreateCard] = useState(false);
   const [createSuccessOpen, setCreateSuccessOpen] = useState(false);
 
@@ -42,7 +77,10 @@ function MoneyPage() {
       ) : (
         <>
           {activeTab === 'monthly' && <MemberExpenseSummary />}
-          <CardsList items={cardListItems} />
+          <CardsList
+            items={cardListItems}
+            initialOpenExpenseId={initialOpenExpenseId}
+          />
         </>
       )}
       <FixedBottomButton onClick={() => setShowCreateCard(true)} label="新增" />

--- a/src/pages/Notification/NotificationPage.tsx
+++ b/src/pages/Notification/NotificationPage.tsx
@@ -177,6 +177,11 @@ function NotificationPage() {
                 expense={expense}
                 groupMembers={groupMembers}
                 label="已執行分帳"
+                onClick={() =>
+                  navigate('/money', {
+                    state: { date: expense.expenseDate, expenseId: expense.id },
+                  })
+                }
               />
             ))}
           </>
@@ -212,6 +217,11 @@ function NotificationPage() {
                 expense={expense}
                 groupMembers={groupMembers}
                 label="待執行分帳"
+                onClick={() =>
+                  navigate('/money', {
+                    state: { date: expense.expenseDate, expenseId: expense.id },
+                  })
+                }
               />
             ))}
           </>

--- a/src/pages/Notification/NotificationPage.tsx
+++ b/src/pages/Notification/NotificationPage.tsx
@@ -150,7 +150,11 @@ function NotificationPage() {
                 eventType="重要任務"
                 title={entry.title}
                 time={format(parseISO(entry.startsAt), 'HH:mm')}
-                onClick={() => {}}
+                onClick={() =>
+                  navigate('/calendar-page', {
+                    state: { selectedDate: entry.startsAt, entryId: entry.id },
+                  })
+                }
               />
             ))}
             {completedImportantEntries.map((entry) => (
@@ -160,7 +164,11 @@ function NotificationPage() {
                 eventType="已完成重要任務"
                 title={entry.title}
                 time={format(parseISO(entry.startsAt), 'HH:mm')}
-                onClick={() => {}}
+                onClick={() =>
+                  navigate('/calendar-page', {
+                    state: { selectedDate: entry.startsAt, entryId: entry.id },
+                  })
+                }
               />
             ))}
             {todaySplitExpenses.map((expense) => (
@@ -191,7 +199,11 @@ function NotificationPage() {
                 eventType="重要任務"
                 title={entry.title}
                 time={format(parseISO(entry.startsAt), 'MM/dd HH:mm')}
-                onClick={() => {}}
+                onClick={() =>
+                  navigate('/calendar-page', {
+                    state: { selectedDate: entry.startsAt, entryId: entry.id },
+                  })
+                }
               />
             ))}
             {upcomingSplitExpenses.map((expense) => (

--- a/src/pages/Notification/NotificationPage.tsx
+++ b/src/pages/Notification/NotificationPage.tsx
@@ -120,13 +120,13 @@ function NotificationPage() {
   }, [allExpenses]);
 
   return (
-    <main className="mx-auto flex min-h-screen w-full max-w-200 flex-col text-neutral-900">
+    <main className="mx-auto flex min-h-screen w-full max-w-200 flex-col bg-neutral-200 text-neutral-900">
       <NavigationGroupTrigger
         groupName={currentGroup?.name ?? ''}
         showBackButton
         onBackClick={() => navigate(-1)}
         onClick={() => setIsGroupDrawerOpen(true)}
-        className="border-b-2 px-6 pb-3.25"
+        className="border-b-2 px-6 py-3.25"
         titleClassName="font-heading-sm"
       />
 

--- a/src/pages/Notification/NotificationPage.tsx
+++ b/src/pages/Notification/NotificationPage.tsx
@@ -1,13 +1,23 @@
 import { useMemo, useState } from 'react';
 
-import { format, isSameDay, parseISO } from 'date-fns';
-import { Bell } from 'lucide-react';
+import {
+  addDays,
+  format,
+  isAfter,
+  isBefore,
+  isSameDay,
+  parseISO,
+  startOfDay,
+} from 'date-fns';
+import { Calendar, Check, ClipboardList, PiggyBank } from 'lucide-react';
 import { useNavigate } from 'react-router';
 
 import BaseDrawer from '@/components/common/BaseDrawer';
 import { NavigationGroupTrigger } from '@/components/common/NavigationBar';
 import GroupManagementDrawer from '@/features/groups/components/GroupManagementDrawer';
+import useGetGroupMembers from '@/features/groups/hooks/useGetGroupMembers';
 import useGetGroups from '@/features/groups/hooks/useGetGroups';
+import useExpenses from '@/features/money/hooks/useExpenses';
 import useCurrentGroupId from '@/hooks/useCurrentGroupID';
 import useGetCareLogEntries from '@/pages/CareLog/hooks/useGetCareLogEntries';
 
@@ -18,17 +28,88 @@ function NotificationPage() {
   const { currentGroupId, setCurrentGroupId } = useCurrentGroupId();
   const { data: groups = [] } = useGetGroups();
   const { entries } = useGetCareLogEntries();
+  const { expenses: thisMonthExpenses } = useExpenses(
+    format(new Date(), 'yyyy-MM'),
+  );
+  const { expenses: nextMonthExpenses } = useExpenses(
+    format(addDays(new Date(), 7), 'yyyy-MM'),
+  );
+  const { data: groupMembers = [] } = useGetGroupMembers(currentGroupId ?? '');
   const [isGroupDrawerOpen, setIsGroupDrawerOpen] = useState(false);
 
   const currentGroup = groups.find((g) => g.id === currentGroupId) ?? groups[0];
 
-  const todayImportantEntries = useMemo(() => {
+  const { pendingImportantEntries, completedImportantEntries } = useMemo(() => {
     const today = new Date();
-
-    return entries.filter(
-      (entry) => entry.isImportant && isSameDay(parseISO(entry.startsAt), today),
-    );
+    const todayImportant = entries
+      .filter(
+        (entry) =>
+          entry.isImportant && isSameDay(parseISO(entry.startsAt), today),
+      )
+      .sort(
+        (a, b) =>
+          parseISO(a.startsAt).getTime() - parseISO(b.startsAt).getTime(),
+      );
+    return {
+      pendingImportantEntries: todayImportant.filter(
+        (e) => e.status === 'pending',
+      ),
+      completedImportantEntries: todayImportant.filter(
+        (e) => e.status === 'completed',
+      ),
+    };
   }, [entries]);
+
+  const allExpenses = useMemo(
+    () => [
+      ...thisMonthExpenses,
+      ...nextMonthExpenses.filter(
+        (e) => !thisMonthExpenses.some((t) => t.id === e.id),
+      ),
+    ],
+    [thisMonthExpenses, nextMonthExpenses],
+  );
+
+  const todaySplitExpenses = useMemo(() => {
+    const todayStr = format(new Date(), 'yyyy-MM-dd');
+    return allExpenses.filter(
+      (expense) =>
+        expense.expenseDate.replace('Z', '').startsWith(todayStr) &&
+        expense.splitStatus !== 'none',
+    );
+  }, [allExpenses]);
+
+  const upcomingImportantEntries = useMemo(() => {
+    const today = startOfDay(new Date());
+    const weekEnd = addDays(today, 7);
+    return entries
+      .filter((entry) => {
+        const date = startOfDay(parseISO(entry.startsAt));
+        return (
+          entry.isImportant &&
+          entry.status === 'pending' &&
+          isAfter(date, today) &&
+          isBefore(date, weekEnd)
+        );
+      })
+      .sort(
+        (a, b) =>
+          parseISO(a.startsAt).getTime() - parseISO(b.startsAt).getTime(),
+      );
+  }, [entries]);
+
+  const upcomingSplitExpenses = useMemo(() => {
+    const today = startOfDay(new Date());
+    const weekEnd = addDays(today, 7);
+    return allExpenses.filter((expense) => {
+      const date = startOfDay(parseISO(expense.expenseDate.replace('Z', '')));
+      return (
+        expense.splitStatus !== 'none' &&
+        isAfter(date, today) &&
+        isBefore(date, weekEnd)
+      );
+    });
+  }, [allExpenses]);
 
   return (
     <main className="mx-auto flex min-h-screen w-full max-w-200 flex-col text-neutral-900">
@@ -42,24 +123,96 @@ function NotificationPage() {
       />
 
       <section className="flex flex-1 flex-col px-6">
-        <div className="font-label-lg flex py-3">今日</div>
-
-        {todayImportantEntries.length === 0 ? (
-          <p className="font-paragraph-sm text-neutral-500">今日沒有重要事件</p>
+        <h2 className="font-label-lg flex py-3">今日</h2>
+        {pendingImportantEntries.length === 0 &&
+        completedImportantEntries.length === 0 &&
+        todaySplitExpenses.length === 0 ? (
+          <NotificationBar
+            icon={<Calendar />}
+            title="目前沒有收到任何通知"
+            showChevron={false}
+          />
         ) : (
-          todayImportantEntries.map((entry) => (
-            <NotificationBar
-              key={entry.id}
-              icon={<Bell />}
-              eventType="重要日誌"
-              title={entry.title}
-              time={format(parseISO(entry.startsAt), 'HH:mm')}
-              onClick={() => {}}
-            />
-          ))
+          <>
+            {pendingImportantEntries.map((entry) => (
+              <NotificationBar
+                key={entry.id}
+                icon={<Calendar />}
+                eventType="重要任務"
+                title={entry.title}
+                time={format(parseISO(entry.startsAt), 'HH:mm')}
+                onClick={() => {}}
+              />
+            ))}
+            {completedImportantEntries.map((entry) => (
+              <NotificationBar
+                key={entry.id}
+                icon={<Check />}
+                eventType="已完成重要任務"
+                title={entry.title}
+                time={format(parseISO(entry.startsAt), 'HH:mm')}
+                onClick={() => {}}
+              />
+            ))}
+            {todaySplitExpenses.map((expense) => {
+              const creator = groupMembers.find(
+                (m) => m.userId === expense.createdBy,
+              );
+              const creatorLabel = creator
+                ? `${creator.username} 已執行分帳`
+                : '已執行分帳';
+              return (
+                <NotificationBar
+                  key={expense.id}
+                  icon={<PiggyBank />}
+                  eventType="分帳紀錄"
+                  title={creatorLabel}
+                  onClick={() => {}}
+                />
+              );
+            })}
+          </>
         )}
-
-        <div className="font-label-lg flex py-3">其他</div>
+        <h2 className="font-label-lg flex py-3">其他</h2>
+        {upcomingImportantEntries.length === 0 &&
+        upcomingSplitExpenses.length === 0 ? (
+          <NotificationBar
+            icon={<ClipboardList />}
+            title="近一週沒有其他通知"
+            showChevron={false}
+            iconClassName="bg-neutral-500 border-neutral-500"
+          />
+        ) : (
+          <>
+            {upcomingImportantEntries.map((entry) => (
+              <NotificationBar
+                key={entry.id}
+                icon={<Calendar />}
+                eventType="重要任務"
+                title={entry.title}
+                time={format(parseISO(entry.startsAt), 'MM/dd HH:mm')}
+                onClick={() => {}}
+              />
+            ))}
+            {upcomingSplitExpenses.map((expense) => {
+              const creator = groupMembers.find(
+                (m) => m.userId === expense.createdBy,
+              );
+              const creatorLabel = creator
+                ? `${creator.username} 已執行分帳`
+                : '已執行分帳';
+              return (
+                <NotificationBar
+                  key={expense.id}
+                  icon={<PiggyBank />}
+                  eventType="分帳紀錄"
+                  title={creatorLabel}
+                  onClick={() => {}}
+                />
+              );
+            })}
+          </>
+        )}
       </section>
 
       <BaseDrawer open={isGroupDrawerOpen} onOpenChange={setIsGroupDrawerOpen}>

--- a/src/pages/Notification/NotificationPage.tsx
+++ b/src/pages/Notification/NotificationPage.tsx
@@ -9,7 +9,7 @@ import {
   parseISO,
   startOfDay,
 } from 'date-fns';
-import { Calendar, Check, ClipboardList, PiggyBank } from 'lucide-react';
+import { Calendar, Check, ClipboardList } from 'lucide-react';
 import { useNavigate } from 'react-router';
 
 import BaseDrawer from '@/components/common/BaseDrawer';
@@ -22,6 +22,7 @@ import useCurrentGroupId from '@/hooks/useCurrentGroupID';
 import useGetCareLogEntries from '@/pages/CareLog/hooks/useGetCareLogEntries';
 
 import NotificationBar from './components/NotificationBar';
+import SplitExpenseBar from './components/SplitExpenseBar';
 
 function NotificationPage() {
   const navigate = useNavigate();
@@ -74,8 +75,8 @@ function NotificationPage() {
     const todayStr = format(new Date(), 'yyyy-MM-dd');
     return allExpenses.filter(
       (expense) =>
-        expense.expenseDate.replace('Z', '').startsWith(todayStr) &&
-        expense.splitStatus !== 'none',
+        expense.splitStatus === 'settled' &&
+        expense.updatedAt.replace('Z', '').startsWith(todayStr),
     );
   }, [allExpenses]);
 
@@ -104,7 +105,7 @@ function NotificationPage() {
     return allExpenses.filter((expense) => {
       const date = startOfDay(parseISO(expense.expenseDate.replace('Z', '')));
       return (
-        expense.splitStatus !== 'none' &&
+        expense.splitStatus === 'pending' &&
         isAfter(date, today) &&
         isBefore(date, weekEnd)
       );
@@ -131,6 +132,7 @@ function NotificationPage() {
             icon={<Calendar />}
             title="目前沒有收到任何通知"
             showChevron={false}
+            iconClassName="bg-neutral-500 border-neutral-500"
           />
         ) : (
           <>
@@ -154,23 +156,14 @@ function NotificationPage() {
                 onClick={() => {}}
               />
             ))}
-            {todaySplitExpenses.map((expense) => {
-              const creator = groupMembers.find(
-                (m) => m.userId === expense.createdBy,
-              );
-              const creatorLabel = creator
-                ? `${creator.username} 已執行分帳`
-                : '已執行分帳';
-              return (
-                <NotificationBar
-                  key={expense.id}
-                  icon={<PiggyBank />}
-                  eventType="分帳紀錄"
-                  title={creatorLabel}
-                  onClick={() => {}}
-                />
-              );
-            })}
+            {todaySplitExpenses.map((expense) => (
+              <SplitExpenseBar
+                key={expense.id}
+                expense={expense}
+                groupMembers={groupMembers}
+                label="已執行分帳"
+              />
+            ))}
           </>
         )}
         <h2 className="font-label-lg flex py-3">其他</h2>
@@ -194,23 +187,14 @@ function NotificationPage() {
                 onClick={() => {}}
               />
             ))}
-            {upcomingSplitExpenses.map((expense) => {
-              const creator = groupMembers.find(
-                (m) => m.userId === expense.createdBy,
-              );
-              const creatorLabel = creator
-                ? `${creator.username} 已執行分帳`
-                : '已執行分帳';
-              return (
-                <NotificationBar
-                  key={expense.id}
-                  icon={<PiggyBank />}
-                  eventType="分帳紀錄"
-                  title={creatorLabel}
-                  onClick={() => {}}
-                />
-              );
-            })}
+            {upcomingSplitExpenses.map((expense) => (
+              <SplitExpenseBar
+                key={expense.id}
+                expense={expense}
+                groupMembers={groupMembers}
+                label="待執行分帳"
+              />
+            ))}
           </>
         )}
       </section>

--- a/src/pages/Notification/NotificationPage.tsx
+++ b/src/pages/Notification/NotificationPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import {
   addDays,
@@ -23,10 +23,16 @@ import useGetCareLogEntries from '@/pages/CareLog/hooks/useGetCareLogEntries';
 
 import NotificationBar from './components/NotificationBar';
 import SplitExpenseBar from './components/SplitExpenseBar';
+import useNotificationBadge from './hooks/useNotificationBadge';
 
 function NotificationPage() {
   const navigate = useNavigate();
+  const { markAsRead } = useNotificationBadge();
   const { currentGroupId, setCurrentGroupId } = useCurrentGroupId();
+
+  useEffect(() => {
+    markAsRead();
+  }, [markAsRead]);
   const { data: groups = [] } = useGetGroups();
   const { entries } = useGetCareLogEntries();
   const { expenses: thisMonthExpenses } = useExpenses(
@@ -53,10 +59,10 @@ function NotificationPage() {
       );
     return {
       pendingImportantEntries: todayImportant.filter(
-        (e) => e.status === 'pending',
+        (entry) => entry.status === 'pending',
       ),
       completedImportantEntries: todayImportant.filter(
-        (e) => e.status === 'completed',
+        (entry) => entry.status === 'completed',
       ),
     };
   }, [entries]);
@@ -65,7 +71,8 @@ function NotificationPage() {
     () => [
       ...thisMonthExpenses,
       ...nextMonthExpenses.filter(
-        (e) => !thisMonthExpenses.some((t) => t.id === e.id),
+        (expense) =>
+          !thisMonthExpenses.some((existing) => existing.id === expense.id),
       ),
     ],
     [thisMonthExpenses, nextMonthExpenses],

--- a/src/pages/Notification/NotificationPage.tsx
+++ b/src/pages/Notification/NotificationPage.tsx
@@ -1,0 +1,83 @@
+import { useMemo, useState } from 'react';
+
+import { format, isSameDay, parseISO } from 'date-fns';
+import { Bell } from 'lucide-react';
+import { useNavigate } from 'react-router';
+
+import BaseDrawer from '@/components/common/BaseDrawer';
+import { NavigationGroupTrigger } from '@/components/common/NavigationBar';
+import GroupManagementDrawer from '@/features/groups/components/GroupManagementDrawer';
+import useGetGroups from '@/features/groups/hooks/useGetGroups';
+import useCurrentGroupId from '@/hooks/useCurrentGroupID';
+import useGetCareLogEntries from '@/pages/CareLog/hooks/useGetCareLogEntries';
+
+import NotificationBar from './components/NotificationBar';
+
+function NotificationPage() {
+  const navigate = useNavigate();
+  const { currentGroupId, setCurrentGroupId } = useCurrentGroupId();
+  const { data: groups = [] } = useGetGroups();
+  const { entries } = useGetCareLogEntries();
+  const [isGroupDrawerOpen, setIsGroupDrawerOpen] = useState(false);
+
+  const currentGroup = groups.find((g) => g.id === currentGroupId) ?? groups[0];
+
+  const todayImportantEntries = useMemo(() => {
+    const today = new Date();
+
+    return entries.filter(
+      (entry) => entry.isImportant && isSameDay(parseISO(entry.startsAt), today),
+    );
+  }, [entries]);
+
+  return (
+    <main className="mx-auto flex min-h-screen w-full max-w-200 flex-col text-neutral-900">
+      <NavigationGroupTrigger
+        groupName={currentGroup?.name ?? ''}
+        showBackButton
+        onBackClick={() => navigate(-1)}
+        onClick={() => setIsGroupDrawerOpen(true)}
+        className="border-b-2 px-6 pb-3.25"
+        titleClassName="font-heading-sm"
+      />
+
+      <section className="flex flex-1 flex-col px-6">
+        <div className="font-label-lg flex py-3">今日</div>
+
+        {todayImportantEntries.length === 0 ? (
+          <p className="font-paragraph-sm text-neutral-500">今日沒有重要事件</p>
+        ) : (
+          todayImportantEntries.map((entry) => (
+            <NotificationBar
+              key={entry.id}
+              icon={<Bell />}
+              eventType="重要日誌"
+              title={entry.title}
+              time={format(parseISO(entry.startsAt), 'HH:mm')}
+              onClick={() => {}}
+            />
+          ))
+        )}
+
+        <div className="font-label-lg flex py-3">其他</div>
+      </section>
+
+      <BaseDrawer open={isGroupDrawerOpen} onOpenChange={setIsGroupDrawerOpen}>
+        <GroupManagementDrawer
+          groups={groups}
+          selectedGroupId={currentGroupId ?? ''}
+          onSelectGroup={(groupId) => {
+            setCurrentGroupId(groupId);
+            setIsGroupDrawerOpen(false);
+          }}
+          onManageGroup={() => {}}
+          onJoinGroup={() => {}}
+          onCreateGroup={() => {}}
+          showManageButton={false}
+        />
+      </BaseDrawer>
+    </main>
+  );
+}
+
+export default NotificationPage;

--- a/src/pages/Notification/components/NotificationBar.tsx
+++ b/src/pages/Notification/components/NotificationBar.tsx
@@ -1,0 +1,41 @@
+import { ChevronRight } from 'lucide-react';
+
+import { CircleButtonPrimary } from '@/components/common/CircleIButton';
+
+type NotificationBarProps = {
+  icon: React.ReactNode;
+  eventType: string;
+  title: string;
+  time: string;
+  onClick?: () => void;
+};
+
+function NotificationBar({
+  icon,
+  eventType,
+  title,
+  time,
+  onClick,
+}: NotificationBarProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="flex w-full items-center gap-3 text-neutral-900"
+    >
+      <CircleButtonPrimary>{icon}</CircleButtonPrimary>
+      <div className="flex flex-1 flex-col text-left">
+        <p className="font-paragraph-md">{eventType}</p>
+        <div className="flex gap-1">
+          <p className="font-paragraph-sm">{time}</p>
+          <p className="font-paragraph-sm">{title}</p>
+        </div>
+      </div>
+      <div className="flex aspect-square w-10 items-center justify-center">
+        <ChevronRight className="size-8" />
+      </div>
+    </button>
+  );
+}
+
+export default NotificationBar;

--- a/src/pages/Notification/components/NotificationBar.tsx
+++ b/src/pages/Notification/components/NotificationBar.tsx
@@ -1,39 +1,51 @@
 import { ChevronRight } from 'lucide-react';
 
 import { CircleButtonPrimary } from '@/components/common/CircleIButton';
+import cn from '@/lib/utils';
 
 type NotificationBarProps = {
   icon: React.ReactNode;
-  eventType: string;
+  iconClassName?: string;
+  eventType?: string;
   title: string;
-  time: string;
+  time?: string;
+  showChevron?: boolean;
   onClick?: () => void;
 };
 
 function NotificationBar({
   icon,
+  iconClassName,
   eventType,
   title,
   time,
+  showChevron = true,
   onClick,
 }: NotificationBarProps) {
   return (
     <button
       type="button"
       onClick={onClick}
-      className="flex w-full items-center gap-3 text-neutral-900"
+      className="flex w-full items-center gap-3 py-2 text-neutral-900"
     >
-      <CircleButtonPrimary>{icon}</CircleButtonPrimary>
+      <CircleButtonPrimary
+        size="notification"
+        className={cn('[&_svg]:size-3', iconClassName)}
+      >
+        {icon}
+      </CircleButtonPrimary>
       <div className="flex flex-1 flex-col text-left">
-        <p className="font-paragraph-md">{eventType}</p>
+        {eventType ? <p className="font-paragraph-md">{eventType}</p> : null}
         <div className="flex gap-1">
-          <p className="font-paragraph-sm">{time}</p>
+          {time ? <p className="font-paragraph-sm">{time}</p> : null}
           <p className="font-paragraph-sm">{title}</p>
         </div>
       </div>
-      <div className="flex aspect-square w-10 items-center justify-center">
-        <ChevronRight className="size-8" />
-      </div>
+      {showChevron ? (
+        <div className="flex aspect-square w-10 items-center justify-center">
+          <ChevronRight className="size-8" />
+        </div>
+      ) : null}
     </button>
   );
 }

--- a/src/pages/Notification/components/SplitExpenseBar.tsx
+++ b/src/pages/Notification/components/SplitExpenseBar.tsx
@@ -1,0 +1,34 @@
+import { PiggyBank } from 'lucide-react';
+
+import type { ExpenseItem } from '@/features/money/types';
+import type { GroupMember } from '@/types/group';
+
+import NotificationBar from './NotificationBar';
+
+type SplitExpenseBarProps = {
+  expense: ExpenseItem;
+  groupMembers: GroupMember[];
+  label?: string;
+  onClick?: () => void;
+};
+
+function SplitExpenseBar({
+  expense,
+  groupMembers,
+  label = '已執行分帳',
+  onClick,
+}: SplitExpenseBarProps) {
+  const creator = groupMembers.find((m) => m.userId === expense.createdBy);
+  const title = creator ? `${creator.username} ${label}` : label;
+
+  return (
+    <NotificationBar
+      icon={<PiggyBank />}
+      eventType="分帳紀錄"
+      title={title}
+      onClick={onClick}
+    />
+  );
+}
+
+export default SplitExpenseBar;

--- a/src/pages/Notification/hooks/useNotificationBadge.ts
+++ b/src/pages/Notification/hooks/useNotificationBadge.ts
@@ -1,0 +1,81 @@
+import { useCallback, useMemo } from 'react';
+
+import { addDays, format, isSameDay, parseISO } from 'date-fns';
+
+import useExpenses from '@/features/money/hooks/useExpenses';
+import useCurrentGroupId from '@/hooks/useCurrentGroupID';
+import useGetCareLogEntries from '@/pages/CareLog/hooks/useGetCareLogEntries';
+
+const getStorageKey = (groupId: string) => `notification_snapshot_${groupId}`;
+
+function computeSnapshot(ids: string[]) {
+  return [...ids].sort().join(',');
+}
+
+function useNotificationBadge() {
+  const { currentGroupId } = useCurrentGroupId();
+  const { entries } = useGetCareLogEntries();
+  const { expenses: thisMonthExpenses } = useExpenses(
+    format(new Date(), 'yyyy-MM'),
+  );
+  const { expenses: nextMonthExpenses } = useExpenses(
+    format(addDays(new Date(), 7), 'yyyy-MM'),
+  );
+
+  const allExpenses = useMemo(
+    () => [
+      ...thisMonthExpenses,
+      ...nextMonthExpenses.filter(
+        (expense) =>
+          !thisMonthExpenses.some((existing) => existing.id === expense.id),
+      ),
+    ],
+    [thisMonthExpenses, nextMonthExpenses],
+  );
+
+  const currentSnapshot = useMemo(() => {
+    const today = new Date();
+    const todayStr = format(today, 'yyyy-MM-dd');
+
+    const pendingIds = entries
+      .filter(
+        (entry) =>
+          entry.isImportant &&
+          isSameDay(parseISO(entry.startsAt), today) &&
+          entry.status === 'pending',
+      )
+      .map((entry) => entry.id);
+
+    const completedIds = entries
+      .filter(
+        (entry) =>
+          entry.isImportant &&
+          isSameDay(parseISO(entry.startsAt), today) &&
+          entry.status === 'completed',
+      )
+      .map((entry) => `c_${entry.id}`);
+
+    const splitIds = allExpenses
+      .filter(
+        (expense) =>
+          expense.splitStatus === 'settled' &&
+          expense.updatedAt.replace('Z', '').startsWith(todayStr),
+      )
+      .map((expense) => `s_${expense.id}`);
+
+    return computeSnapshot([...pendingIds, ...completedIds, ...splitIds]);
+  }, [entries, allExpenses]);
+
+  const storageKey = getStorageKey(currentGroupId ?? '');
+  const storedSnapshot = localStorage.getItem(storageKey) ?? '';
+  const hasUnread =
+    currentSnapshot !== '' && currentSnapshot !== storedSnapshot;
+
+  const markAsRead = useCallback(() => {
+    localStorage.setItem(storageKey, currentSnapshot);
+  }, [storageKey, currentSnapshot]);
+
+  return { hasUnread, markAsRead };
+}
+
+export default useNotificationBadge;

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -11,6 +11,7 @@ import HomepagePage from '@/pages/Homepage/HomepagePage';
 import LandingPage from '@/pages/LandingPage';
 import LoginPage from '@/pages/LoginPage';
 import MoneyPage from '@/pages/MoneyPage';
+import NotificationPage from '@/pages/Notification/NotificationPage';
 import OnboardingPage from '@/pages/OnboardingPage';
 import RegistrationPage from '@/pages/RegistrationPage';
 
@@ -66,6 +67,10 @@ const router = createHashRouter([
       {
         path: 'money',
         Component: MoneyPage,
+      },
+      {
+        path: 'notifications',
+        Component: NotificationPage,
       },
     ],
   },


### PR DESCRIPTION
 - Add notification page (`/notifications`) with two sections: Today and Upcoming (next 7 days)                                                                      
  - Today: shows important tasks (pending / completed) and split expenses settled today                                                                              
  - Upcoming: shows important tasks and pending split expenses within the next 7 days
  - Add unread badge on homepage bell icon using localStorage snapshot; clears on  page visit                                                                         
  - Tapping a notification navigates to the related detail — tasks open CalendarPage with detail drawer, split expenses open MoneyPage with expense detail