### PR TITLE
Update/group drawer name fields

### DIFF
--- a/src/components/common/ListFormRows.tsx
+++ b/src/components/common/ListFormRows.tsx
@@ -227,7 +227,7 @@ function ListFormNameRow({
   return (
     <ListFormRow label={label} htmlFor={htmlFor} className={className}>
       <Input
-        placeholder="輸入名稱"
+        placeholder={inputProps?.placeholder ?? '輸入名稱'}
         className="font-paragraph-md h-auto border-0 bg-transparent px-0 py-0 pr-4 text-right text-neutral-900 shadow-none placeholder:text-neutral-600 focus-visible:border-0 focus-visible:ring-0 focus-visible:ring-offset-0"
         id={htmlFor}
         {...inputProps}

--- a/src/features/groups/components/GroupEntryDrawer.tsx
+++ b/src/features/groups/components/GroupEntryDrawer.tsx
@@ -308,6 +308,7 @@ function GroupEntryDrawer({
             <ListFormNameRow
               label="群組名稱"
               inputProps={{
+                placeholder: '輸入群組名稱',
                 value: groupName,
                 onChange: (event) => setGroupName(event.target.value),
               }}
@@ -315,6 +316,7 @@ function GroupEntryDrawer({
             <ListFormNameRow
               label="被照護者名稱"
               inputProps={{
+                placeholder: '輸入被照護者名稱',
                 value: careRecipientName,
                 onChange: (event) => setCareRecipientName(event.target.value),
               }}

--- a/src/features/groups/components/GroupEntryDrawer.tsx
+++ b/src/features/groups/components/GroupEntryDrawer.tsx
@@ -170,16 +170,16 @@ function GroupEntryDrawer({
   const [step, setStep] = useState<DrawerStep>(initialStep);
   const [createdInviteCode, setCreatedInviteCode] = useState('');
   const [groupName, setGroupName] = useState(initialGroupName);
-  const [careRecipientName, setCareRecipientName] = useState('');
+  const [careRecipientName, setCareRecipientName] =
+    useState(initialRecipientName);
   const [gender, setGender] = useState(initialRecipientGender);
   const [birthDate, setBirthDate] = useState(initialRecipientBirthDate);
   const [description] = useState(initialDescription);
   const [healthStatus] = useState(initialHealthStatus);
   const isEditMode = mode === 'edit';
   const isSubmitting = isLoading || isUpdating;
-  const canSubmit = isEditMode
-    ? groupName.trim().length > 0
-    : careRecipientName.trim().length > 0;
+  const canSubmit =
+    groupName.trim().length > 0 && careRecipientName.trim().length > 0;
   const successTitle = isEditMode ? '編輯完成！' : '創建完成！';
   const formTitle = isEditMode ? '編輯群組' : '建立照護群組';
   const formDescription = isEditMode
@@ -244,7 +244,7 @@ function GroupEntryDrawer({
     }
 
     const result = await handleCreateGroup({
-      name: careRecipientName,
+      name: groupName,
       recipientName: careRecipientName,
       recipientGender: gender,
       recipientBirthDate: birthDate,
@@ -305,23 +305,20 @@ function GroupEntryDrawer({
 
         <div className="flex flex-col">
           <div className="mb-20 flex flex-col gap-2">
-            {isEditMode ? (
-              <ListFormNameRow
-                label="群組名稱"
-                inputProps={{
-                  value: groupName,
-                  onChange: (event) => setGroupName(event.target.value),
-                }}
-              />
-            ) : (
-              <ListFormNameRow
-                label="被照護者名稱"
-                inputProps={{
-                  value: careRecipientName,
-                  onChange: (event) => setCareRecipientName(event.target.value),
-                }}
-              />
-            )}
+            <ListFormNameRow
+              label="群組名稱"
+              inputProps={{
+                value: groupName,
+                onChange: (event) => setGroupName(event.target.value),
+              }}
+            />
+            <ListFormNameRow
+              label="被照護者名稱"
+              inputProps={{
+                value: careRecipientName,
+                onChange: (event) => setCareRecipientName(event.target.value),
+              }}
+            />
             <ListFormGenderRow
               label="被照護者性別"
               value={gender}


### PR DESCRIPTION
- Add a separate group name field in the group entry drawer
- Use the group name as the create group payload name
- Add clearer placeholders for group and care recipient inputs