### PR TITLE
Update/money-drawer-and-group-entry-flow

### DIFF
--- a/src/components/common/BaseDrawer.tsx
+++ b/src/components/common/BaseDrawer.tsx
@@ -42,7 +42,7 @@ function BaseDrawer({
 
       <DrawerContent
         className={cn(
-          'rounded-t-3xl border-0 bg-neutral-100 px-6 pb-7',
+          'mx-auto w-full max-w-[800px] rounded-t-3xl border-0 bg-neutral-100 px-6 pb-7',
           className,
         )}
         handleClassName={handleClassName}

--- a/src/components/common/UpgradeCTADrawer.tsx
+++ b/src/components/common/UpgradeCTADrawer.tsx
@@ -16,10 +16,11 @@ function UpgradeCTADrawer({ open, onOpenChange }: UpgradeCTADrawerProps) {
       className="border-t-neutral-800 bg-neutral-800 ring-neutral-800"
     >
       <div className="relative mb-5 flex items-center justify-center">
+        <div className="absolute left-0 size-6" aria-hidden="true" />
         <button
           type="button"
           aria-label="關閉操作選單"
-          className="absolute left-0 inline-flex size-6 items-center justify-center text-neutral-100"
+          className="absolute right-0 inline-flex size-6 items-center justify-center text-neutral-100"
           onClick={() => onOpenChange(false)}
         >
           <X className="size-8" strokeWidth={1.5} />

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -31,7 +31,7 @@ const AlertDialogBackdrop = React.forwardRef<
   <DialogPrimitive.Backdrop
     ref={ref}
     className={cn(
-      'fixed inset-0 z-70 bg-black/25 transition-opacity duration-400 data-ending-style:opacity-0 data-starting-style:opacity-0',
+      'fixed inset-0 z-100 bg-black/25 transition-opacity duration-400 data-ending-style:opacity-0 data-starting-style:opacity-0',
       className,
     )}
     {...props}
@@ -46,7 +46,7 @@ const AlertDialogPopup = React.forwardRef<
   <DialogPrimitive.Popup
     ref={ref}
     className={cn(
-      'fixed top-1/2 left-1/2 z-80 w-[calc(100vw-48px)] max-w-92.25 -translate-x-1/2 -translate-y-1/2 rounded-sm border-2 border-neutral-900 bg-neutral-50 transition-transform duration-400 data-ending-style:translate-y-[calc(-50%+8px)] data-ending-style:opacity-0 data-starting-style:translate-y-[calc(-50%+8px)]',
+      'fixed top-1/2 left-1/2 z-110 w-[calc(100vw-48px)] max-w-92.25 -translate-x-1/2 -translate-y-1/2 rounded-sm border-2 border-neutral-900 bg-neutral-50 transition-transform duration-400 data-ending-style:translate-y-[calc(-50%+8px)] data-ending-style:opacity-0 data-starting-style:translate-y-[calc(-50%+8px)]',
       className,
     )}
     {...props}

--- a/src/features/groups/components/GroupActionDrawer.tsx
+++ b/src/features/groups/components/GroupActionDrawer.tsx
@@ -66,6 +66,11 @@ function GroupActionDrawer({
     >
       <div className="flex flex-col gap-2 text-neutral-900">
         <div className="flex items-center justify-between">
+          {groupName ? (
+            <p className="font-label-sm text-neutral-700">{groupName}</p>
+          ) : (
+            <div />
+          )}
           <button
             type="button"
             aria-label="關閉群組操作選單"
@@ -74,9 +79,6 @@ function GroupActionDrawer({
           >
             <X className="size-8" strokeWidth={1.5} />
           </button>
-          {groupName ? (
-            <p className="font-label-sm text-neutral-700">{groupName}</p>
-          ) : null}
         </div>
 
         <div className="divide-y divide-neutral-400 overflow-hidden rounded-[8px] bg-neutral-300">

--- a/src/features/groups/components/GroupEntryDrawer.tsx
+++ b/src/features/groups/components/GroupEntryDrawer.tsx
@@ -287,17 +287,33 @@ function GroupEntryDrawer({
   if (step === 'create') {
     return (
       <div className="flex flex-col text-neutral-900">
-        <div className="relative mb-5 flex items-center justify-center py-2">
-          <button
-            type="button"
-            aria-label="關閉建立群組視窗"
-            onClick={onClose}
-            className="absolute left-0 inline-flex size-10 items-center justify-center"
-          >
-            <X className="size-8" strokeWidth={2} />
-          </button>
-          <h2 className="font-label-lg">{formTitle}</h2>
-        </div>
+        {isEditMode ? (
+          <div className="mb-5 flex items-center justify-between py-2">
+            <button
+              type="button"
+              aria-label="關閉編輯群組視窗"
+              onClick={onClose}
+              className="inline-flex size-10 items-center justify-center"
+            >
+              <X className="size-8" strokeWidth={2} />
+            </button>
+            <h2 className="font-label-lg text-right">
+              {groupName.trim() || formTitle}
+            </h2>
+          </div>
+        ) : (
+          <div className="relative mb-5 flex items-center justify-center py-2">
+            <button
+              type="button"
+              aria-label="關閉建立群組視窗"
+              onClick={onClose}
+              className="absolute left-0 inline-flex size-10 items-center justify-center"
+            >
+              <X className="size-8" strokeWidth={2} />
+            </button>
+            <h2 className="font-label-lg">{formTitle}</h2>
+          </div>
+        )}
 
         <p className="font-paragraph-md mx-auto pb-3 text-neutral-900">
           {formDescription}

--- a/src/features/groups/components/GroupEntryDrawer.tsx
+++ b/src/features/groups/components/GroupEntryDrawer.tsx
@@ -303,15 +303,16 @@ function GroupEntryDrawer({
           </div>
         ) : (
           <div className="relative mb-5 flex items-center justify-center py-2">
+            <div className="absolute left-0 size-10" aria-hidden="true" />
+            <h2 className="font-label-lg">{formTitle}</h2>
             <button
               type="button"
               aria-label="關閉建立群組視窗"
               onClick={onClose}
-              className="absolute left-0 inline-flex size-10 items-center justify-center"
+              className="absolute right-0 inline-flex size-10 items-center justify-center"
             >
               <X className="size-8" strokeWidth={2} />
             </button>
-            <h2 className="font-label-lg">{formTitle}</h2>
           </div>
         )}
 

--- a/src/features/groups/components/GroupInviteDrawer.tsx
+++ b/src/features/groups/components/GroupInviteDrawer.tsx
@@ -48,11 +48,12 @@ function GroupInviteDrawer({
       <BaseDrawer open={open} onOpenChange={onOpenChange}>
         <div className="flex flex-col text-neutral-900">
           <div className="relative mb-8 flex items-center justify-center py-2">
+            <div className="absolute left-0 size-10" aria-hidden="true" />
             <button
               type="button"
               aria-label="關閉邀請成員視窗"
               onClick={() => onOpenChange(false)}
-              className="absolute left-0 inline-flex size-10 items-center justify-center"
+              className="absolute right-0 inline-flex size-10 items-center justify-center"
             >
               <X className="size-8" strokeWidth={1.5} />
             </button>

--- a/src/features/groups/components/GroupJoinDrawer.tsx
+++ b/src/features/groups/components/GroupJoinDrawer.tsx
@@ -119,11 +119,12 @@ function GroupJoinDrawer({
     drawerContent = (
       <div className="flex flex-col text-neutral-900">
         <div className="relative mb-5 flex items-center justify-center py-2">
+          <div className="absolute left-0 size-10" aria-hidden="true" />
           <button
             type="button"
             aria-label="關閉加入群組視窗"
             onClick={() => onOpenChange(false)}
-            className="absolute left-0 inline-flex size-10 items-center justify-center"
+            className="absolute right-0 inline-flex size-10 items-center justify-center"
           >
             <X className="size-8" strokeWidth={1.5} />
           </button>
@@ -171,11 +172,12 @@ function GroupJoinDrawer({
     drawerContent = (
       <div className="flex flex-col text-neutral-900">
         <div className="relative flex items-center justify-center py-2">
+          <div className="absolute left-0 size-10" aria-hidden="true" />
           <button
             type="button"
             aria-label="關閉加入群組視窗"
             onClick={() => onOpenChange(false)}
-            className="absolute left-0 inline-flex size-10 items-center justify-center"
+            className="absolute right-0 inline-flex size-10 items-center justify-center"
           >
             <X className="size-8" strokeWidth={1.5} />
           </button>

--- a/src/features/groups/components/GroupJoinDrawer.tsx
+++ b/src/features/groups/components/GroupJoinDrawer.tsx
@@ -105,12 +105,7 @@ function GroupJoinDrawer({
       return;
     }
 
-    if (onSuccess) {
-      onOpenChange(false);
-      onSuccess();
-    } else {
-      setIsJoinSuccess(true);
-    }
+    setIsJoinSuccess(true);
   };
 
   let drawerContent: React.ReactNode;

--- a/src/features/groups/components/GroupMemberManagementDrawer.tsx
+++ b/src/features/groups/components/GroupMemberManagementDrawer.tsx
@@ -43,22 +43,18 @@ function GroupMemberManagementDrawer({
     <BaseDrawer open={open} onOpenChange={onOpenChange}>
       <div className="flex flex-col gap-5 text-neutral-900">
         <div className="grid grid-cols-[1fr_auto_1fr] items-center">
-          {isEditMode ? (
-            <button
-              type="button"
-              className="font-paragraph-md justify-self-start text-neutral-900"
-              onClick={() => setIsEditMode(false)}
-            >
-              返回
-            </button>
-          ) : (
-            <div />
-          )}
+          {isEditMode ? <div /> : <div />}
           <p className="font-label-lg text-center">
             {isEditMode ? '編輯成員' : '成員管理'}
           </p>
           {isEditMode ? (
-            <div />
+            <button
+              type="button"
+              className="font-paragraph-md justify-self-end text-neutral-900"
+              onClick={() => setIsEditMode(false)}
+            >
+              返回
+            </button>
           ) : (
             <button
               type="button"

--- a/src/features/money/components/EntryCard.tsx
+++ b/src/features/money/components/EntryCard.tsx
@@ -9,7 +9,6 @@ import {
 } from '@/components/common/CardLabel';
 import Modal from '@/components/common/Modal';
 import SingleAvatar from '@/components/common/SingleAvatar';
-import UpdateDeleteDrawer from '@/components/common/UpdateDeleteDrawer';
 import {
   AlertDialog,
   AlertDialogBackdrop,
@@ -35,7 +34,6 @@ function EntryCard({
   const { currentGroupId } = useCurrentGroupId();
   const { data: groupMembers = [] } = useGetGroupMembers(currentGroupId);
   const creator = groupMembers.find((m) => m.userId === item.createdBy);
-  const [drawerOpen, setDrawerOpen] = useState(false);
   const [dialogOpen, setDialogOpen] = useState(initialOpen);
   const [updateOpen, setUpdateOpen] = useState(false);
   const [updateSuccessOpen, setUpdateSuccessOpen] = useState(false);
@@ -86,10 +84,10 @@ function EntryCard({
                 <button
                   type="button"
                   aria-label="更多選項"
-                  className="flex size-6 items-center justify-center text-neutral-600"
+                  className="flex size-6 items-center justify-center text-neutral-900"
                   onClick={(e) => {
                     e.stopPropagation();
-                    setDrawerOpen(true);
+                    setDialogOpen(true);
                   }}
                 >
                   <EllipsisVertical className="size-4" strokeWidth={2.5} />
@@ -140,15 +138,6 @@ function EntryCard({
           </AlertDialogPopup>
         </AlertDialogPortal>
       </AlertDialog>
-
-      <UpdateDeleteDrawer
-        open={drawerOpen}
-        onOpenChange={setDrawerOpen}
-        editLabel="編輯帳目"
-        deleteLabel="刪除帳目"
-        onEdit={handleEditClick}
-        onDelete={handleDeleteClick}
-      />
 
       <Modal
         open={confirmOpen}

--- a/src/features/money/components/EntryCard.tsx
+++ b/src/features/money/components/EntryCard.tsx
@@ -14,7 +14,6 @@ import {
   AlertDialogBackdrop,
   AlertDialogPopup,
   AlertDialogPortal,
-  AlertDialogTrigger,
 } from '@/components/ui/alert-dialog';
 import useGetGroupMembers from '@/features/groups/hooks/useGetGroupMembers';
 import useDeleteMoneyItem from '@/features/money/hooks/useDeleteMoneyItem';
@@ -68,47 +67,54 @@ function EntryCard({
   return (
     <>
       <AlertDialog open={dialogOpen} onOpenChange={setDialogOpen}>
-        <AlertDialogTrigger className="block w-full text-left">
-          <div className="w-full rounded-sm border-2 border-neutral-900 bg-neutral-100 p-4">
-            <div className="flex items-center justify-between border-b-2 border-neutral-900 pb-3">
-              <span className="font-label-lg text-neutral-900">
-                {item.title}
-              </span>
-              <div className="flex items-center gap-2">
-                {item.splitStatus === 'settled' && (
-                  <CardLabelPrimary>已分帳</CardLabelPrimary>
-                )}
-                {item.splitStatus === 'pending' && (
-                  <CardLabelSecondary>需分帳</CardLabelSecondary>
-                )}
-                <button
-                  type="button"
-                  aria-label="更多選項"
-                  className="flex size-6 items-center justify-center text-neutral-900"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    setDialogOpen(true);
-                  }}
-                >
-                  <EllipsisVertical className="size-4" strokeWidth={2.5} />
-                </button>
-              </div>
-            </div>
-
-            <div className="flex items-center justify-between pt-2">
-              <span className="font-label-lg text-neutral-900">
-                $ {(item.amount ?? 0).toLocaleString()}
-              </span>
-              {creator && (
-                <SingleAvatar
-                  src={getAvatarSrcByKey(creator.avatarKey)}
-                  name={creator.username}
-                  className="size-7 ring-neutral-900"
-                />
+        <div
+          className="w-full rounded-sm border-2 border-neutral-900 bg-neutral-100 p-4 text-left"
+          role="button"
+          tabIndex={0}
+          onClick={() => setDialogOpen(true)}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+              event.preventDefault();
+              setDialogOpen(true);
+            }
+          }}
+        >
+          <div className="flex items-center justify-between border-b-2 border-neutral-900 pb-3">
+            <span className="font-label-lg text-neutral-900">{item.title}</span>
+            <div className="flex items-center gap-2">
+              {item.splitStatus === 'settled' && (
+                <CardLabelPrimary>已分帳</CardLabelPrimary>
               )}
+              {item.splitStatus === 'pending' && (
+                <CardLabelSecondary>需分帳</CardLabelSecondary>
+              )}
+              <button
+                type="button"
+                aria-label="更多選項"
+                className="flex size-6 items-center justify-center text-neutral-900"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setDialogOpen(true);
+                }}
+              >
+                <EllipsisVertical className="size-4" strokeWidth={2.5} />
+              </button>
             </div>
           </div>
-        </AlertDialogTrigger>
+
+          <div className="flex items-center justify-between pt-2">
+            <span className="font-label-lg text-neutral-900">
+              $ {(item.amount ?? 0).toLocaleString()}
+            </span>
+            {creator && (
+              <SingleAvatar
+                src={getAvatarSrcByKey(creator.avatarKey)}
+                name={creator.username}
+                className="size-7 ring-neutral-900"
+              />
+            )}
+          </div>
+        </div>
 
         <AlertDialogPortal>
           <AlertDialogBackdrop />

--- a/src/pages/Homepage/components/CreateEntryDrawer.tsx
+++ b/src/pages/Homepage/components/CreateEntryDrawer.tsx
@@ -70,21 +70,17 @@ function CreateEntryDrawer({
       className={cn('px-6', className)}
     >
       <div className="flex flex-col gap-2 text-neutral-900">
-        <div className="flex items-center">
-          <div className="flex w-10 justify-start">
-            <button
-              type="button"
-              aria-label="關閉新增選單"
-              className="inline-flex size-10 items-center justify-center"
-              onClick={() => onOpenChange(false)}
-            >
-              <X className="size-8" strokeWidth={1.5} />
-            </button>
-          </div>
-          <div className="flex-1 text-center">
-            <p className="font-label-lg">建立</p>
-          </div>
-          <div className="w-10" />
+        <div className="relative flex items-center justify-center">
+          <div className="absolute left-0 size-10" aria-hidden="true" />
+          <p className="font-label-lg">建立</p>
+          <button
+            type="button"
+            aria-label="關閉新增選單"
+            className="absolute right-0 inline-flex size-10 items-center justify-center"
+            onClick={() => onOpenChange(false)}
+          >
+            <X className="size-8" strokeWidth={1.5} />
+          </button>
         </div>
 
         <div className="divide-y divide-neutral-400 overflow-hidden rounded-lg bg-neutral-300">


### PR DESCRIPTION
- Move drawer close buttons to the right in the create entry, group invite, and upgrade CTA drawers
- Keep drawer titles centered while updating the header layout for consistency
- Raise alert dialog z-index so copy-link success feedback appears above drawers