### PR TITLE
Fix/form-overlay-layering

### DIFF
--- a/src/components/common/ListFormRows.tsx
+++ b/src/components/common/ListFormRows.tsx
@@ -704,7 +704,7 @@ function ListFormDateTimeRow({
             {dateValue}
           </button>
           {onDateChange && isDateOpen ? (
-            <div className="absolute top-full right-0 z-50 mt-2 rounded-sm bg-neutral-200 p-2 shadow-md ring-2 ring-neutral-900">
+            <div className="absolute top-full right-0 z-120 mt-2 rounded-sm bg-neutral-200 p-2 text-neutral-900 shadow-md ring-2 ring-neutral-900">
               <div className="flex gap-2">
                 <Select
                   value={String(selectedYear)}
@@ -772,7 +772,7 @@ function ListFormDateTimeRow({
             {timeValue}
           </button>
           {onTimeChange && isTimeOpen ? (
-            <div className="absolute top-full right-0 z-50 mt-2 rounded-sm bg-neutral-200 p-2 text-neutral-900 shadow-md ring-2 ring-neutral-900">
+            <div className="absolute top-full right-0 z-120 mt-2 rounded-sm bg-neutral-200 p-2 text-neutral-900 shadow-md ring-2 ring-neutral-900">
               <div className="flex gap-2">
                 <Select
                   value={parsedTime.period}

--- a/src/components/common/ScrollableDatePicker.tsx
+++ b/src/components/common/ScrollableDatePicker.tsx
@@ -112,7 +112,7 @@ function ScrollableDatePicker({
       {onChange && isOpen ? (
         <div
           data-vaul-no-drag=""
-          className="absolute right-0 bottom-full z-50 mb-2 rounded-sm bg-neutral-200 p-2 shadow-md ring-2 ring-neutral-900"
+          className="absolute right-0 bottom-full z-120 mb-2 rounded-sm bg-neutral-200 p-2 shadow-md ring-2 ring-neutral-900"
         >
           <div className="flex gap-2">
             <div

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -111,13 +111,13 @@ function SelectContent({
         align={align}
         alignOffset={alignOffset}
         alignItemWithTrigger={alignItemWithTrigger}
-        className="isolate z-90"
+        className="isolate z-120"
       >
         <SelectPrimitive.Popup
           data-slot="select-content"
           data-align-trigger={alignItemWithTrigger}
           className={cn(
-            'bg-popover text-popover-foreground ring-foreground/10 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 relative isolate z-90 max-h-(--available-height) w-(--anchor-width) min-w-36 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-lg shadow-md ring-1 duration-100 data-[align-trigger=true]:animate-none',
+            'bg-popover text-popover-foreground ring-foreground/10 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 relative isolate z-120 max-h-(--available-height) w-(--anchor-width) min-w-36 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-lg shadow-md ring-1 duration-100 data-[align-trigger=true]:animate-none',
             className,
           )}
           {...props}


### PR DESCRIPTION
- Raise form date and time picker layers so they render above modal overlays
- Fix the money date picker panel text visibility by applying the correct foreground color
- Update shared select popup layering to keep year, month, day, and time dropdowns usable inside form dialogs