### PR TITLE
Update/group-drawer-task-border-home-align

### DIFF
--- a/src/features/groups/components/GroupEntryDrawer.tsx
+++ b/src/features/groups/components/GroupEntryDrawer.tsx
@@ -101,7 +101,10 @@ function DrawerActionStep({
         <RoundedButtonPrimary onClick={onPrimaryClick}>
           {primaryLabel}
         </RoundedButtonPrimary>
-        <RoundedButtonSecondary onClick={onSecondaryClick}>
+        <RoundedButtonSecondary
+          className="border-0 bg-neutral-100 text-neutral-600"
+          onClick={onSecondaryClick}
+        >
           {secondaryLabel}
         </RoundedButtonSecondary>
       </div>

--- a/src/pages/CareLog/CalendarPage.tsx
+++ b/src/pages/CareLog/CalendarPage.tsx
@@ -125,7 +125,7 @@ function CalendarPage() {
         onMenuClick={() => setIsSideMenuOpen(true)}
       />
 
-      <section className="bg-primary-default border-y border-neutral-900">
+      <section className="bg-primary-default border-b border-neutral-900">
         <div className="mx-auto w-full max-w-200 px-4 py-5">
           <Calendar
             mode="single"

--- a/src/pages/Homepage/components/UpcomingImportantEntryNotice.tsx
+++ b/src/pages/Homepage/components/UpcomingImportantEntryNotice.tsx
@@ -15,7 +15,7 @@ function UpcomingImportantEntryNotice({
       <Bell className="size-8 shrink-0" />
       <div className="flex min-w-0 flex-col">
         <p className="font-label-md">即將到來的重要行程</p>
-        <div className="flex items-center justify-center gap-1">
+        <div className="flex items-center gap-1">
           <p className="font-label-md truncate">
             {format(parseISO(entry.startsAt), 'HH:mm')}
           </p>


### PR DESCRIPTION
  - Restyle group entry success secondary button to borderless with light
  neutral background so it stops competing with the primary action
  - Drop top border on care log calendar section (border-y → border-b) so it
  doesn't double up with the navigation bar above
  - Remove justify-center on UpcomingImportantEntryNotice row so time and title
  left-align consistently regardless of title length